### PR TITLE
update vinecop examples

### DIFF
--- a/examples/vine_copulas.ipynb
+++ b/examples/vine_copulas.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -18,32 +18,14 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Create a vine copula model"
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "<pyvinecopulib.Vinecop>\n",
-      "** Tree: 0\n",
-      "3,1 <-> BB1 90°, parameters = 3\n",
-      "2\n",
-      "2,1 <-> BB1 90°, parameters = 3\n",
-      "2\n",
-      "** Tree: 1\n",
-      "3,2 | 1 <-> BB1 90°, parameters = 3\n",
-      "2\n",
-      "\n"
-     ]
+     "text": "<pyvinecopulib.Vinecop>\n** Tree: 0\n3,1 <-> BB1 90°, parameters = 3\n2\n2,1 <-> BB1 90°, parameters = 3\n2\n** Tree: 1\n3,2 | 1 <-> BB1 90°, parameters = 3\n2\n\n"
     }
    ],
    "source": [
@@ -55,7 +37,7 @@
     "mat = np.array([[1, 1, 1], [2, 2, 0], [3, 0, 0]])\n",
     "\n",
     "# Set-up a vine copula\n",
-    "cop = pv.Vinecop(pcs, mat)\n",
+    "cop = pv.Vinecop(mat, pcs)\n",
     "print(cop)"
    ]
   },
@@ -70,41 +52,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "text/plain": [
-       "[array([ 44.67583001,  54.34974545,  29.84989695,  19.18643731,\n",
-       "        199.72159236, 944.18332674,  21.78049474,  43.78532554,\n",
-       "          9.10911159,  13.39339764]),\n",
-       " array([[0.1638618 , 0.8170847 , 0.12668051],\n",
-       "        [0.90118677, 0.11345478, 0.2222099 ],\n",
-       "        [0.62193432, 0.12286857, 0.39604429],\n",
-       "        [0.6902412 , 0.78638305, 0.37455509],\n",
-       "        [0.13685699, 0.10872534, 0.2777274 ],\n",
-       "        [0.03952828, 0.35645124, 0.06597532],\n",
-       "        [0.48023317, 0.77472657, 0.72886036],\n",
-       "        [0.19787956, 0.90877192, 0.60171   ],\n",
-       "        [0.85523898, 0.76413881, 0.04961411],\n",
-       "        [0.17627362, 0.77807695, 0.03875948]]),\n",
-       " array([[0.1638618 , 0.8728502 , 0.79397093],\n",
-       "        [0.90118677, 0.03148971, 0.30865931],\n",
-       "        [0.62193432, 0.28213894, 0.46366853],\n",
-       "        [0.6902412 , 0.28590505, 0.30879851],\n",
-       "        [0.13685699, 0.88594611, 0.84611164],\n",
-       "        [0.03952828, 0.97430917, 0.95100319],\n",
-       "        [0.48023317, 0.53494551, 0.47865733],\n",
-       "        [0.19787956, 0.84458738, 0.75111263],\n",
-       "        [0.85523898, 0.10561078, 0.19326385],\n",
-       "        [0.17627362, 0.8605475 , 0.77931921]]),\n",
-       " 37.9568529234207,\n",
-       " -63.913705846841395,\n",
-       " -62.09819528887712]"
-      ]
+      "text/plain": "[array([ 44.67583001,  54.34974545,  29.84989695,  19.18643731,\n        199.72159236, 944.18332674,  21.78049474,  43.78532554,\n          9.10911159,  13.39339764]),\n array([[0.1638618 , 0.8170847 , 0.12668051],\n        [0.90118677, 0.11345478, 0.2222099 ],\n        [0.62193432, 0.12286857, 0.39604429],\n        [0.6902412 , 0.78638305, 0.37455509],\n        [0.13685699, 0.10872534, 0.2777274 ],\n        [0.03952828, 0.35645124, 0.06597532],\n        [0.48023317, 0.77472657, 0.72886036],\n        [0.19787956, 0.90877192, 0.60171   ],\n        [0.85523898, 0.76413881, 0.04961411],\n        [0.17627362, 0.77807695, 0.03875948]]),\n array([[0.1638618 , 0.8728502 , 0.79397093],\n        [0.90118677, 0.03148971, 0.30865931],\n        [0.62193432, 0.28213894, 0.46366853],\n        [0.6902412 , 0.28590505, 0.30879851],\n        [0.13685699, 0.88594611, 0.84611164],\n        [0.03952828, 0.97430917, 0.95100319],\n        [0.48023317, 0.53494551, 0.47865733],\n        [0.19787956, 0.84458738, 0.75111263],\n        [0.85523898, 0.10561078, 0.19326385],\n        [0.17627362, 0.8605475 , 0.77931921]]),\n 37.9568529234207,\n -63.913705846841395,\n -62.09819528887712]"
      },
-     "execution_count": 3,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -120,39 +75,25 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Create a vine copula model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Different ways to fit a copula (when the families and structure are known)..."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "<pyvinecopulib.Vinecop>\n",
-      "** Tree: 0\n",
-      "3,1 <-> BB1 90°, parameters = 2.92727\n",
-      "2.02245\n",
-      "2,1 <-> BB1 90°, parameters = 2.98212\n",
-      "2.04269\n",
-      "** Tree: 1\n",
-      "3,2 | 1 <-> BB1 90°, parameters = 2.72951\n",
-      "2.04219\n",
-      "\n",
-      "<pyvinecopulib.Vinecop>\n",
-      "** Tree: 0\n",
-      "3,1 <-> BB1 90°, parameters = 2.92727\n",
-      "2.02245\n",
-      "2,1 <-> BB1 90°, parameters = 2.98212\n",
-      "2.04269\n",
-      "** Tree: 1\n",
-      "3,2 | 1 <-> BB1 90°, parameters = 2.72951\n",
-      "2.04219\n",
-      "\n"
-     ]
+     "text": "<pyvinecopulib.Vinecop>\n** Tree: 0\n3,1 <-> BB1 90°, parameters = 2.92727\n2.02245\n2,1 <-> BB1 90°, parameters = 2.98212\n2.04269\n** Tree: 1\n3,2 | 1 <-> BB1 90°, parameters = 2.72951\n2.04219\n\n<pyvinecopulib.Vinecop>\n** Tree: 0\n3,1 <-> BB1 90°, parameters = 2.92727\n2.02245\n2,1 <-> BB1 90°, parameters = 2.98212\n2.04269\n** Tree: 1\n3,2 | 1 <-> BB1 90°, parameters = 2.72951\n2.04219\n\n"
     }
    ],
    "source": [
@@ -164,9 +105,9 @@
     "#    - see help(pv.FitControlsVinecop) for more details\n",
     "controls = pv.FitControlsVinecop(family_set=[pv.BicopFamily.bb1])\n",
     "\n",
-    "# Create a new object an sets its parameters by fitting afterwards\n",
-    "cop2 = pv.Vinecop(pcs, mat)\n",
-    "cop2.select_families(data=u, controls=controls)\n",
+    "# Create a new object an select family and parameters by fitting to data\n",
+    "cop2 = pv.Vinecop(mat, pcs)\n",
+    "cop2.select(data=u, controls=controls)\n",
     "print(cop2)\n",
     "\n",
     "# Otherwise, create directly from data\n",
@@ -183,44 +124,59 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "<pyvinecopulib.Vinecop>\n",
-      "** Tree: 0\n",
-      "2,1 <-> BB1 90°, parameters = 2.98212\n",
-      "2.04269\n",
-      "1,3 <-> BB6 90°, parameters = 1.54273\n",
-      "3.96417\n",
-      "** Tree: 1\n",
-      "2,3 | 1 <-> Gumbel 90°, parameters = 4.82967\n",
-      "\n",
-      "<pyvinecopulib.Vinecop>\n",
-      "** Tree: 0\n",
-      "2,1 <-> BB1 90°, parameters = 2.98212\n",
-      "2.04269\n",
-      "1,3 <-> BB6 90°, parameters = 1.54273\n",
-      "3.96417\n",
-      "** Tree: 1\n",
-      "2,3 | 1 <-> Gumbel 90°, parameters = 4.82967\n",
-      "\n"
-     ]
+     "text": "<pyvinecopulib.Vinecop>\n** Tree: 0\n2,1 <-> BB1 90°, parameters = 2.98212\n2.04269\n1,3 <-> BB6 90°, parameters = 1.54273\n3.96417\n** Tree: 1\n2,3 | 1 <-> Gumbel 90°, parameters = 4.82967\n\n<pyvinecopulib.Vinecop>\n** Tree: 0\n2,1 <-> BB1 90°, parameters = 2.98212\n2.04269\n1,3 <-> BB6 90°, parameters = 1.54273\n3.96417\n** Tree: 1\n2,3 | 1 <-> Gumbel 90°, parameters = 4.82967\n\n"
     }
    ],
    "source": [
-    "# Create a new object an selects families and parameters afterwards\n",
+    "# Create a new object and select strucutre, family, and parameters\n",
     "cop3 = pv.Vinecop(d=3)\n",
-    "cop3.select_all(data=u)\n",
+    "cop3.select(data=u)\n",
     "print(cop3)\n",
     "\n",
     "# Otherwise, create directly from data\n",
     "cop3 = pv.Vinecop(data=u)\n",
     "print(cop3)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": "<pyvinecopulib.Vinecop>\n** Tree: 0\n4,1 <-> Gaussian, parameters = 0.5\n3,1 <-> Clayton, parameters = 3\n2,1 <-> Student, parameters = 0.4\n  4\n** Tree: 1\n4,2 | 1 <-> Independence\n3,2 | 1 <-> Gaussian, parameters = 0.5\n** Tree: 2\n4,3 | 1 <-> Gaussian, parameters = 0.5\n\n"
+    }
+   ],
+   "source": [
+    "# create a C-vine structure with root node 1 in first tree, 2 in second, ...\n",
+    "cvine = pv.CVineStructure([4, 3, 2, 1]) \n",
+    "# specify pair-copulas in every tree\n",
+    "tree1 = [pv.Bicop(pv.BicopFamily.gaussian, 0, [0.5]), \n",
+    "         pv.Bicop(pv.BicopFamily.clayton, 0, [3]),\n",
+    "         pv.Bicop(pv.BicopFamily.student, 0, [0.4, 4])]\n",
+    "tree2 = [pv.Bicop(pv.BicopFamily.indep), \n",
+    "         pv.Bicop(pv.BicopFamily.gaussian, 0, [0.5])]\n",
+    "tree3 = [pv.Bicop(pv.BicopFamily.gaussian)]\n",
+    "\n",
+    "# instantiate C-vine copula model\n",
+    "cop = pv.Vinecop(cvine, [tree1, tree2, tree3])\n",
+    "print(cop)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -239,7 +195,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Related to #50. 
- examples didn't complete b/c our change in `mat/pcs` argument order
- added a quick example with a 4-dimensional C-vine