### PR TITLE
remove build deps from runtime

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,9 +33,6 @@ classifiers = [
         'License :: OSI Approved :: MIT License'
 ]
 dependencies = [
-  'pybind11>=2.10.0',
-  'setuptools>=64.0.0',
-  'setuptools_scm>=8.0.0',
   'numpy>=1.14'
 ]
 


### PR DESCRIPTION
It seems that these dependencies are not required at runtime, only at build time