### PR TITLE
Add variables names option for vinecop plots

### DIFF
--- a/src/include/vinecop/class.hpp
+++ b/src/include/vinecop/class.hpp
@@ -194,7 +194,8 @@ init_vinecop_class(py::module_& module)
       [](const Vinecop& cop,
          py::object tree = py::none(),
          bool add_edge_labels = true,
-         const std::string& layout = "graphviz") {
+         const std::string& layout = "graphviz",
+         py::object vars_names = py::none()) {
         auto python_helpers_plotting =
           py::module_::import("pyvinecopulib._python_helpers.vinecop");
 
@@ -202,11 +203,12 @@ init_vinecop_class(py::module_& module)
         py::object vinecop_plot = python_helpers_plotting.attr("vinecop_plot");
 
         // Call the Python function with the C++ object and additional arguments
-        vinecop_plot(py::cast(cop), tree, add_edge_labels, layout);
+        vinecop_plot(py::cast(cop), tree, add_edge_labels, layout, vars_names);
       },
       py::arg("tree") = py::none(),
       py::arg("add_edge_labels") = true,
       py::arg("layout") = "graphviz",
+      py::arg("vars_names") = py::none(),
       py::cast<std::string>(
         py::module_::import("pyvinecopulib._python_helpers.vinecop")
           .attr("VINECOP_PLOT_DOC"))


### PR DESCRIPTION
```
import numpy as np
import pyvinecopulib as pv


def random_data(d=5, n=1000):
  # Simulate some data
  np.random.seed(1234)  # seed for the random generator
  mean = np.random.normal(size=d)  # mean vector
  cov = np.random.normal(size=(d, d))  # covariance matrix
  cov = np.dot(cov.transpose(), cov)  # make it non-negative definite
  x = np.random.multivariate_normal(mean, cov, n)
  return x

d = 5
n = 1000
u = pv.to_pseudo_obs(random_data(d, n))

controls = pv.FitControlsVinecop(family_set=[pv.BicopFamily.gaussian])
cop = pv.Vinecop(u, controls=controls)
cop.plot()

var_names = [f"X{i}" for i in range(d)]
cop.plot(vars_names=var_names)
```

![image](https://github.com/user-attachments/assets/ad5beb2d-93a0-4fa8-9d16-fdee61fc82c8)

![image](https://github.com/user-attachments/assets/d2790768-8615-4044-a011-75d9163cebea)


