### PR TITLE
Speed up with O3 compiler optimizations

### DIFF
--- a/examples/benchmark.ipynb
+++ b/examples/benchmark.ipynb
@@ -1,0 +1,91 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Benchmark results (in seconds):\n",
+      "Vinecop with family_set='itau': min=2.271671, mean=2.311788, max=2.376060\n",
+      "Vinecop with family_set='itau' and par_method='itau': min=0.247383, mean=0.249442, max=0.255479\n"
+     ]
+    }
+   ],
+   "source": [
+    "import timeit\n",
+    "\n",
+    "import numpy as np\n",
+    "import pyvinecopulib as pv\n",
+    "\n",
+    "# Set parameters\n",
+    "n = 500\n",
+    "d = 3\n",
+    "\n",
+    "# Generate data\n",
+    "x = np.random.normal(size=(n, d)) * np.ones((n, d)) + 0.5 * np.random.normal(\n",
+    "  size=(n, d)\n",
+    ")\n",
+    "\n",
+    "# Convert data to pseudo-observations\n",
+    "u = pv.to_pseudo_obs(x)\n",
+    "\n",
+    "controls_itau = pv.FitControlsVinecop(family_set=pv.itau)\n",
+    "controls_itau_par_method = pv.FitControlsVinecop(\n",
+    "  family_set=pv.itau, parametric_method=\"itau\"\n",
+    ")\n",
+    "\n",
+    "\n",
+    "# Define two different configurations of the `vinecop` function\n",
+    "def vinecop_itau():\n",
+    "  return pv.Vinecop(u, controls=controls_itau)\n",
+    "\n",
+    "\n",
+    "def vinecop_itau_par_method():\n",
+    "  return pv.Vinecop(u, controls=controls_itau_par_method)\n",
+    "\n",
+    "\n",
+    "# Benchmark the functions\n",
+    "times_vinecop_itau = timeit.repeat(\n",
+    "  \"vinecop_itau()\", globals=globals(), repeat=10, number=1\n",
+    ")\n",
+    "times_vinecop_itau_par_method = timeit.repeat(\n",
+    "  \"vinecop_itau_par_method()\", globals=globals(), repeat=10, number=1\n",
+    ")\n",
+    "\n",
+    "# Display benchmark results\n",
+    "print(\"Benchmark results (in seconds):\")\n",
+    "print(\n",
+    "  f\"Vinecop with family_set='itau': min={min(times_vinecop_itau):.6f}, mean={np.mean(times_vinecop_itau):.6f}, max={max(times_vinecop_itau):.6f}\"\n",
+    ")\n",
+    "print(\n",
+    "  f\"Vinecop with family_set='itau' and par_method='itau': min={min(times_vinecop_itau_par_method):.6f}, mean={np.mean(times_vinecop_itau_par_method):.6f}, max={max(times_vinecop_itau_par_method):.6f}\"\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "pyvinecopulib311",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/benchmark.ipynb
+++ b/examples/benchmark.ipynb
@@ -2,16 +2,17 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Benchmark results (in seconds):\n",
-      "Vinecop with family_set='itau': min=2.271671, mean=2.311788, max=2.376060\n",
-      "Vinecop with family_set='itau' and par_method='itau': min=0.247383, mean=0.249442, max=0.255479\n"
+      "Unit: milliseconds:\n",
+      "vinecop_itau: min=897.365909, mean=905.054253, max=916.135056\n",
+      "vinecop_itau_par_method: min=88.986936, mean=89.999466, max=91.964365\n",
+      "vinecop_tll: min=52.166149, mean=53.964570, max=59.898893\n"
      ]
     }
    ],
@@ -19,11 +20,17 @@
     "import timeit\n",
     "\n",
     "import numpy as np\n",
+    "\n",
     "import pyvinecopulib as pv\n",
     "\n",
+    "# TODO: Check TLL because compiler might have large impact on performance there\n",
+    "\n",
     "# Set parameters\n",
+    "# n = 1000\n",
+    "# d = 10\n",
     "n = 500\n",
-    "d = 3\n",
+    "d = 5\n",
+    "\n",
     "\n",
     "# Generate data\n",
     "x = np.random.normal(size=(n, d)) * np.ones((n, d)) + 0.5 * np.random.normal(\n",
@@ -33,10 +40,11 @@
     "# Convert data to pseudo-observations\n",
     "u = pv.to_pseudo_obs(x)\n",
     "\n",
-    "controls_itau = pv.FitControlsVinecop(family_set=pv.itau)\n",
+    "controls_itau = pv.FitControlsVinecop(family_set=pv.itau, num_threads=1)\n",
     "controls_itau_par_method = pv.FitControlsVinecop(\n",
-    "  family_set=pv.itau, parametric_method=\"itau\"\n",
+    "  family_set=pv.itau, parametric_method=\"itau\", num_threads=1\n",
     ")\n",
+    "controls_tll = pv.FitControlsVinecop(family_set=[pv.tll], num_threads=1)\n",
     "\n",
     "\n",
     "# Define two different configurations of the `vinecop` function\n",
@@ -48,28 +56,33 @@
     "  return pv.Vinecop(u, controls=controls_itau_par_method)\n",
     "\n",
     "\n",
+    "def vinecop_tll():\n",
+    "  return pv.Vinecop(u, controls=controls_tll)\n",
+    "\n",
+    "\n",
     "# Benchmark the functions\n",
-    "times_vinecop_itau = timeit.repeat(\n",
-    "  \"vinecop_itau()\", globals=globals(), repeat=10, number=1\n",
-    ")\n",
-    "times_vinecop_itau_par_method = timeit.repeat(\n",
-    "  \"vinecop_itau_par_method()\", globals=globals(), repeat=10, number=1\n",
-    ")\n",
+    "results = {}\n",
+    "for func in [vinecop_itau, vinecop_itau_par_method, vinecop_tll]:\n",
+    "  result = timeit.repeat(lambda: func(), globals=globals(), repeat=10, number=1)\n",
+    "  results[func.__name__] = result\n",
+    "\n",
+    "\n",
+    "def print_results(results, name):\n",
+    "  print(\n",
+    "    f\"{name}: min={min(results)*1000:.6f}, mean={np.mean(results)*1000:.6f}, max={max(results)*1000:.6f}\"\n",
+    "  )\n",
+    "\n",
     "\n",
     "# Display benchmark results\n",
-    "print(\"Benchmark results (in seconds):\")\n",
-    "print(\n",
-    "  f\"Vinecop with family_set='itau': min={min(times_vinecop_itau):.6f}, mean={np.mean(times_vinecop_itau):.6f}, max={max(times_vinecop_itau):.6f}\"\n",
-    ")\n",
-    "print(\n",
-    "  f\"Vinecop with family_set='itau' and par_method='itau': min={min(times_vinecop_itau_par_method):.6f}, mean={np.mean(times_vinecop_itau_par_method):.6f}, max={max(times_vinecop_itau_par_method):.6f}\"\n",
-    ")"
+    "print(\"Unit: milliseconds:\")\n",
+    "for name, result in results.items():\n",
+    "  print_results(result, name)\n"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "pyvinecopulib311",
+   "display_name": "pyvinecopulib",
    "language": "python",
    "name": "python3"
   },
@@ -83,7 +96,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.11.10"
   }
  },
  "nbformat": 4,

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
       include_dirs=include_dirs,
       language="c++",
       cxx_std=17,
+      extra_compile_args=["-O3"],
     )
   ],
   cmdclass={"build_ext": build_ext},


### PR DESCRIPTION
Running the stuff in `benchmark.ipynb`, before:

```
Benchmark results (in seconds):
Vinecop with family_set='itau': min=2.271671, mean=2.311788, max=2.376060
Vinecop with family_set='itau' and par_method='itau': min=0.247383, mean=0.249442, max=0.255479
```

After:

```
Benchmark results (in seconds):
Vinecop with family_set='itau': min=1.975574, mean=2.036852, max=2.157104
Vinecop with family_set='itau' and par_method='itau': min=0.242433, mean=0.256952, max=0.324442
```