### PR TITLE
Upgrade to nanobind v0.2.7 and fix related hacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ mamba install conda-forge::pyvinecopulib
 The main build time prerequisites are:
 
 * scikit-build-core (>=0.4.3),
-* nanobind (>=2.5.0),
+* nanobind (>=2.7.0),
 * a compiler with C++17 support.
 
 To install from source, `Eigen` and `Boost` also need to be available, and CMake will try to find suitable versions automatically.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core >=0.4.3", "nanobind >=2.5.0"]
+requires = ["scikit-build-core >=0.4.3", "nanobind >=2.7.0"]
 build-backend = "scikit_build_core.build"
 
 [project]

--- a/src/include/bicop/class.hpp
+++ b/src/include/bicop/class.hpp
@@ -106,7 +106,7 @@ Alternatives to instantiate bivariate copulas are:
                  "The copula rotation.")
     .def_prop_rw(
       "parameters",
-      [](Bicop& self) { return nb::cast(self.get_parameters()); },
+      &Bicop::get_parameters,
       [](Bicop& self, const nb::DRef<Eigen::MatrixXd>& parameters) {
         self.set_parameters(parameters);
       },
@@ -152,18 +152,12 @@ Alternatives to instantiate bivariate copulas are:
          &Bicop::tau_to_parameters,
          "tau"_a,
          bicop_doc.tau_to_parameters.doc)
-    .def_prop_ro(
-      "parameters_lower_bounds",
-      [](const Bicop& self) {
-        return nb::cast(self.get_parameters_lower_bounds());
-      },
-      bicop_doc.get_parameters_lower_bounds.doc)
-    .def_prop_ro(
-      "parameters_upper_bounds",
-      [](const Bicop& self) {
-        return nb::cast(self.get_parameters_upper_bounds());
-      },
-      bicop_doc.get_parameters_upper_bounds.doc)
+    .def_prop_ro("parameters_lower_bounds",
+                 &Bicop::get_parameters_lower_bounds,
+                 bicop_doc.get_parameters_lower_bounds.doc)
+    .def_prop_ro("parameters_upper_bounds",
+                 &Bicop::get_parameters_upper_bounds,
+                 bicop_doc.get_parameters_upper_bounds.doc)
     .def("pdf", &Bicop::pdf, "u"_a, bicop_doc.pdf.doc)
     .def("cdf", &Bicop::cdf, "u"_a, bicop_doc.cdf.doc)
     .def("hfunc1", &Bicop::hfunc1, "u"_a, bicop_doc.hfunc1.doc)

--- a/src/include/vinecop/class.hpp
+++ b/src/include/vinecop/class.hpp
@@ -195,14 +195,11 @@ are:
          "Gets the rotation of a pair-copula.",
          "tree"_a,
          "edge"_a)
-    .def(
-      "get_parameters",
-      [](const Vinecop& self, size_t tree, size_t edge) {
-        return nb::cast(self.get_parameters(tree, edge));
-      },
-      "Gets the parameters of a pair-copula.",
-      "tree"_a,
-      "edge"_a)
+    .def("get_parameters",
+         &Vinecop::get_parameters,
+         "Gets the parameters of a pair-copula.",
+         "tree"_a,
+         "edge"_a)
     .def("get_tau",
          &Vinecop::get_tau,
          "Gets the kendall's tau of a pair-copula.",

--- a/src/include/vinecop/class.hpp
+++ b/src/include/vinecop/class.hpp
@@ -226,9 +226,7 @@ are:
     .def_prop_ro(
       "npars", &Vinecop::get_npars, "The total number of parameters.")
     .def_prop_ro(
-      "matrix",
-      [](const Vinecop& self) { return nb::cast(self.get_matrix()); },
-      "Extracts the R-vine structure's matrix.")
+      "matrix", &Vinecop::get_matrix, "Extracts the R-vine structure's matrix.")
     .def_prop_ro("nobs",
                  &Vinecop::get_nobs,
                  "The number of observations (for fitted objects only).")

--- a/src/include/vinecop/rvine_structure.hpp
+++ b/src/include/vinecop/rvine_structure.hpp
@@ -117,13 +117,11 @@ Alternatives to instantiate structures are:
     .def_prop_ro(
       "trunc_lvl", &RVineStructure::get_trunc_lvl, "The truncation level.")
     .def_prop_ro("order",
-                 (std::vector<size_t>(RVineStructure::*)() const) &
+                 (std::vector<size_t> (RVineStructure::*)() const) &
                    RVineStructure::get_order,
                  "The variable order.")
     .def_prop_ro(
-      "matrix",
-      [](const RVineStructure& self) { return nb::cast(self.get_matrix()); },
-      rvinestructure_doc.get_matrix.doc)
+      "matrix", &RVineStructure::get_matrix, rvinestructure_doc.get_matrix.doc)
     .def("struct_array",
          &RVineStructure::struct_array,
          "tree"_a,

--- a/tests/test_bicop.py
+++ b/tests/test_bicop.py
@@ -52,6 +52,7 @@ def test_bicop():
 
   bicop.parameters = np.array([[3.0]])
   assert bicop.parameters.shape == (1, 1)
+  assert bicop.parameters[0, 0] == 3.0
 
   bicop.var_types = ["d", "d"]
   assert bicop.var_types == ["d", "d"]
@@ -105,10 +106,12 @@ def test_bicop():
   # Test parameters_lower_bounds method
   lower_bounds = bicop.parameters_lower_bounds
   assert isinstance(lower_bounds, np.ndarray)
+  assert lower_bounds == np.array([1.0])
 
   # Test parameters_upper_bounds method
   upper_bounds = bicop.parameters_upper_bounds
   assert isinstance(upper_bounds, np.ndarray)
+  assert lower_bounds == np.array([50.0])
 
   for method in ["pdf", "cdf", "hfunc1", "hfunc2", "hinv1", "hinv2"]:
     values = getattr(bicop, method)(u)

--- a/tests/test_bicop.py
+++ b/tests/test_bicop.py
@@ -111,7 +111,7 @@ def test_bicop():
   # Test parameters_upper_bounds method
   upper_bounds = bicop.parameters_upper_bounds
   assert isinstance(upper_bounds, np.ndarray)
-  assert lower_bounds == np.array([50.0])
+  assert upper_bounds == np.array([50.0])
 
   for method in ["pdf", "cdf", "hfunc1", "hfunc2", "hinv1", "hinv2"]:
     values = getattr(bicop, method)(u)

--- a/tests/test_vinecop.py
+++ b/tests/test_vinecop.py
@@ -18,31 +18,40 @@ def test_vinecop():
   cop = pv.Vinecop.from_data(u, controls=controls)
 
   # Test get_pair_copula method
-  pair_copula = cop.get_pair_copula(0, 0)
-  assert isinstance(pair_copula, pv.Bicop)
+  for t in range(1, d):
+    for e in range(d - t - 1):
+      pair_copula = cop.get_pair_copula(t, e)
+      assert isinstance(pair_copula, pv.Bicop)
 
-  # Test get_family method
-  family = cop.get_family(0, 0)
-  assert family == pv.BicopFamily.gaussian
+      # Test get_family method
+      family = cop.get_family(0, 0)
+      assert family == pv.BicopFamily.gaussian
 
-  # Test get_rotation method
-  rotation = cop.get_rotation(0, 0)
-  assert rotation == 0
+      # Test get_rotation method
+      rotation = cop.get_rotation(0, 0)
+      assert rotation == 0
 
-  # Test get_parameters method
-  parameters = cop.get_parameters(0, 0)
-  assert isinstance(parameters, np.ndarray)
-  assert parameters.shape == (1, 1)
-  assert -1 < parameters[0, 0] < 1
+      # Test get_parameters method
+      parameters = cop.get_parameters(0, 0)
+      assert isinstance(parameters, np.ndarray)
+      assert parameters.shape == (1, 1)
+      assert -1 < parameters[0, 0] < 1
 
-  # Test get_tau method
-  tau = cop.get_tau(0, 0)
-  assert isinstance(tau, float)
+      # Test get_tau method
+      tau = cop.get_tau(0, 0)
+      assert isinstance(tau, float)
 
   for method in ["pdf", "cdf"]:
     values = getattr(cop, method)(u)
     assert isinstance(values, np.ndarray)
     assert values.shape == (n,)
+    assert values.dtype == np.float64
+
+  for method in ["rosenblatt", "inverse_rosenblatt"]:
+    values = getattr(cop, method)(u)
+    assert isinstance(values, np.ndarray)
+    assert values.shape == (n, d)
+    assert values.dtype == np.float64
 
   # Test passing a single row of data (#169 & #170 fix)
   u1 = u[0, :].reshape(1, d)

--- a/tests/test_vinecop.py
+++ b/tests/test_vinecop.py
@@ -32,6 +32,8 @@ def test_vinecop():
   # Test get_parameters method
   parameters = cop.get_parameters(0, 0)
   assert isinstance(parameters, np.ndarray)
+  assert parameters.shape == (1, 1)
+  assert -1 < parameters[0, 0] < 1
 
   # Test get_tau method
   tau = cop.get_tau(0, 0)
@@ -75,7 +77,13 @@ def test_vinecop():
 
   # Test order and structure
   assert isinstance(cop.order, list)
+  assert set(cop.order) == set(range(1, d + 1))
   assert isinstance(cop.structure, pv.RVineStructure)
+  matrix = cop.matrix
+  assert isinstance(matrix, np.ndarray)
+  assert matrix.shape == (d, d)
+  assert matrix.dtype == np.uint64
+  assert np.all(np.logical_and(matrix >= 0, matrix <= d))
 
   # Test to_json and from_json
   new_cop = pv.Vinecop.from_json(cop.to_json())
@@ -92,13 +100,18 @@ def test_vinecop():
 
 
 def test_rvinestructure():
+  d = 5
   # Test RVineStructure class
-  rvine = pv.RVineStructure(5)
+  rvine = pv.RVineStructure(d)
   assert isinstance(rvine, pv.RVineStructure)
-  assert rvine.dim == 5
-  assert rvine.matrix.shape == (5, 5)
-  assert rvine.trunc_lvl == 4
-  assert rvine.order == list(range(1, 6))
+  assert rvine.dim == d
+  assert rvine.trunc_lvl == d - 1
+  assert rvine.order == list(range(1, d + 1))
+  matrix = rvine.matrix
+  assert isinstance(matrix, np.ndarray)
+  assert matrix.shape == (d, d)
+  assert matrix.dtype == np.uint64
+  assert np.all(np.logical_and(matrix >= 0, matrix <= d))
 
   # Should be the same as the previous one
   dvine = pv.DVineStructure(rvine.order)


### PR DESCRIPTION
The release of nanobind 0.2.7 fixes unnecessary castings. See [this discussion](https://github.com/wjakob/nanobind/discussions/812) for more context.