### PR TITLE
Improve module landing pages + use autosummary for free functions

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -291,7 +291,10 @@ def _write_features_rst(out_path):
   """Generate the auto-summary RST for the public API.
 
   One section per subpackage (core / families / utils), each with an
-  autosummary toctree of its classes and (if any) explicit autofunctions.
+  autosummary toctree for its classes and for its free functions. The
+  toctree directive generates one detail page per object under
+  `_generate/` and a one-line-summary table on the module landing
+  page, matching sklearn's `sklearn.metrics`-style layout.
   """
   rst_name = "API Documentation"
   bar = "=" * len(rst_name)
@@ -313,8 +316,9 @@ def _write_features_rst(out_path):
       functions = contents.get("functions", [])
       if functions:
         f.write("Functions\n^^^^^^^^^\n\n")
+        f.write(".. autosummary::\n    :toctree: _generate\n\n")
         for fn in functions:
-          f.write(f".. autofunction:: {module}.{fn}\n")
+          f.write(f"    {module}.{fn}\n")
         f.write("\n")
 
 

--- a/scripts/generate_stubs.py
+++ b/scripts/generate_stubs.py
@@ -203,8 +203,14 @@ def cleanup_stub(stub: str) -> str:
   #   - inputs accept the broad `ArrayLike` (lists, scalars, buffers …)
   #   - returns are concretely `NDArray[Any]` (subscriptable, supports
   #     arithmetic — accurate for nanobind output).
+  # Match `numpy.ndarray[ … ]` / `np.ndarray[ … ]` with up to two levels of
+  # nested brackets in the parameter list (covers `ndarray[tuple[Any, ...],
+  # dtype[Any]]`-style annotations emitted by recent nanobind versions).
+  # The plain non-greedy `.*?` previously used here breaks on the first `]`,
+  # producing trailing-`]` syntax errors in the generated stubs.
   ndarray_pattern = re.compile(
-    r"numpy\.ndarray\[.*?\]|np\.ndarray\[.*?\]|\bnumpy\.ndarray\b|\bnp\.ndarray\b"
+    r"(?:numpy|np)\.ndarray\[(?:[^\[\]]|\[(?:[^\[\]]|\[[^\[\]]*\])*\])*\]"
+    r"|\bnumpy\.ndarray\b|\bnp\.ndarray\b"
   )
 
   def _rewrite_def_line(match: re.Match) -> str:

--- a/src/include/bicop/family.hpp
+++ b/src/include/bicop/family.hpp
@@ -19,7 +19,9 @@ inline void init_bicop_family(nb::module_& module) {
   nb::enum_<BicopFamily>(module, "BicopFamily", R"pbdoc(
     A bivariate copula family identifier.
 
-    Contains the following families:
+    Members of this enum are the family tags used throughout the API
+    (e.g. as values inside ``FitControlsBicop.family_set`` or returned
+    by :meth:`pyvinecopulib.core.Bicop.family`):
 
       - ``indep``: Independent copula,
       - ``gaussian``: Gaussian copula,
@@ -35,36 +37,9 @@ inline void init_bicop_family(nb::module_& module) {
       - ``tawn``: Tawn copula,
       - ``tll``: Transformation local-likelihood (nonparametric) copula.
 
-    The following convenient sets of families are provided:
-
-      - ``all`` contains all the families,
-      - ``parametric`` contains the parametric families (all except ``tll``),
-      - ``nonparametric`` contains the nonparametric families
-        (``indep`` and ``tll``),
-      - ``one_par`` contains the parametric families with a single parameter
-        (``gaussian``, ``clayton``, ``gumbel``, ``frank``, and ``joe``),
-      - ``two_par`` contains the parametric families with two parameters
-        (``student``, ``bb1``, ``bb6``, ``bb7``, and ``bb8``),
-      - ``three_par`` contains the parametric families with three parameters
-        (``tawn``),
-      - ``elliptical`` contains the elliptical families (``gaussian`` and
-        ``student``),
-      - ``archimedean`` contains the archimedean families (``clayton``,
-        ``gumbel``, ``frank``, ``joe``, ``bb1``, ``bb6``, ``bb7``, and ``bb8``),
-      - ``extreme_value`` contains the extreme value families (``tawn`` and
-        ``gumbel``),
-      - ``bb`` contains the BB families (``bb1``, ``bb6``, ``bb7``, and
-        ``bb8``),
-      - ``itau`` families for which estimation by Kendall's tau inversion is
-        available (``indep``, ``gaussian``, ``student``, ``clayton``,
-        ``gumbel``, ``frank``, ``joe``),
-      - ``lt`` contains the families that are lower-tail dependent (``clayton``,
-        ``bb1``, ``bb7``, ``tawn``),
-      - ``ut`` contains the families that are upper-tail dependent (``gumbel``,
-        ``joe``, ``bb1``, ``bb6``, ``bb7``, ``bb8``, ``tawn``),
-      - ``rotationless`` contains families that don't have a rotation
-        because they already cover positive and negative dependence (``indep``,
-        ``gaussian``, ``student``, ``frank``, ``tll``).
+    See the :mod:`pyvinecopulib.families` module documentation for the
+    named family-group constants (``parametric``, ``elliptical``,
+    ``archimedean``, ``bb``, ``itau``, ...).
     )pbdoc")
       .value("indep", BicopFamily::indep, bicopfamily_doc.indep.doc)
       .value("gaussian", BicopFamily::gaussian, bicopfamily_doc.gaussian.doc)

--- a/src/pyvinecopulib/core/__init__.py
+++ b/src/pyvinecopulib/core/__init__.py
@@ -1,4 +1,42 @@
-"""Core classes: Bicop, Vinecop, fit controls, and vine structures."""
+"""Core copula classes.
+
+The core API exposes the bivariate copula model (:class:`Bicop`), the
+vine copula model (:class:`Vinecop`), the three flavours of regular
+vine structure used to describe how pair-copulas compose
+(:class:`RVineStructure`, :class:`CVineStructure`,
+:class:`DVineStructure`), and the fit-control objects that carry the
+hyperparameters for both fits (:class:`FitControlsBicop` and
+:class:`FitControlsVinecop`).
+
+When to use what
+----------------
+
+- **Bivariate dependence** — :class:`Bicop`. Pick a family explicitly
+  via :meth:`Bicop.from_family` or fit one from data with
+  :meth:`Bicop.from_data`; the family set considered during selection
+  is controlled by :class:`FitControlsBicop` and the family tags from
+  :mod:`pyvinecopulib.families`.
+- **Multivariate dependence** — :class:`Vinecop`. The factory
+  :meth:`Vinecop.from_data` runs the Dissmann algorithm by default
+  (``tree_algorithm="mst_prim"`` on :class:`FitControlsVinecop`);
+  passing ``"random_weighted"`` switches to Wilson-weighted random
+  trees instead, and supplying a hand-crafted
+  :class:`RVineStructure` (or one drawn from
+  :meth:`RVineStructure.simulate`) skips structure selection
+  entirely.
+- **C-vine / D-vine special cases** — :class:`CVineStructure` and
+  :class:`DVineStructure` are the path-shaped and star-shaped
+  specialisations of :class:`RVineStructure` and can be passed
+  anywhere an R-vine is accepted.
+
+For higher-level scikit-learn-compatible wrappers around these
+primitives (with ``fit`` / ``predict``-style interfaces, DataFrame
+handling, and ensemble methods), see
+:mod:`pyvinecopulib.sklearn`. The
+``examples/02_vine_copulas.ipynb`` and
+``examples/03_vine_copulas_fit_sample.ipynb`` notebooks walk through
+end-to-end use of these classes.
+"""
 
 from ..pyvinecopulib_ext import (
   Bicop,

--- a/src/pyvinecopulib/families/__init__.py
+++ b/src/pyvinecopulib/families/__init__.py
@@ -1,8 +1,72 @@
-"""Bicop family constants and groupings.
+"""Bivariate copula families.
 
-Re-exports the `BicopFamily` enum plus the individual family constants
-(`indep`, `gaussian`, ...) and the named family groups (`all`, `parametric`,
-...) from the C++ extension.
+Every bivariate copula model in pyvinecopulib (and every pair-copula
+inside a vine) belongs to one of the families listed below. The
+:class:`BicopFamily` enum holds the family tag; the module-level
+constants ``indep``, ``gaussian``, ... are aliases for the enum members
+so that callers can write ``family_set=[gaussian, student]`` without
+the qualified prefix. The named family-group constants (``parametric``,
+``elliptical``, ``itau``, ...) are pre-built lists you can pass to
+:class:`pyvinecopulib.core.FitControlsBicop` /
+:class:`pyvinecopulib.core.FitControlsVinecop` to constrain the
+fitting search space.
+
+Available families
+------------------
+
+Grouped by mathematical class:
+
+- **Independence** — ``indep``.
+- **Elliptical** — ``gaussian``, ``student``.
+- **Archimedean** (single-parameter) — ``clayton``, ``gumbel``,
+  ``frank``, ``joe``.
+- **Archimedean — BB family (two-parameter extensions)** — ``bb1``,
+  ``bb6``, ``bb7``, ``bb8``.
+- **Extreme-value** — ``tawn`` (three parameters); ``gumbel`` is also
+  an extreme-value copula.
+- **Nonparametric** — ``tll`` (transformation local-likelihood
+  estimator).
+
+See :class:`BicopFamily` for the per-member identifier.
+
+Family groups
+-------------
+
+Convenience lists of :class:`BicopFamily` values:
+
+- ``all`` — every family above.
+- ``parametric`` — every family except ``tll``.
+- ``nonparametric`` — ``indep``, ``tll``.
+- ``one_par`` — single-parameter parametric families
+  (``gaussian``, ``clayton``, ``gumbel``, ``frank``, ``joe``).
+- ``two_par`` — two-parameter parametric families
+  (``student``, ``bb1``, ``bb6``, ``bb7``, ``bb8``).
+- ``three_par`` — three-parameter parametric families (``tawn``).
+- ``elliptical`` — ``gaussian``, ``student``.
+- ``archimedean`` — ``clayton``, ``gumbel``, ``frank``, ``joe``,
+  ``bb1``, ``bb6``, ``bb7``, ``bb8``.
+- ``extreme_value`` — ``tawn``, ``gumbel``.
+- ``bb`` — ``bb1``, ``bb6``, ``bb7``, ``bb8``.
+- ``itau`` — families that support estimation by Kendall's-:math:`\\tau`
+  inversion (``indep``, ``gaussian``, ``student``, ``clayton``,
+  ``gumbel``, ``frank``, ``joe``).
+- ``lt`` — lower-tail dependent families (``clayton``, ``bb1``,
+  ``bb7``, ``tawn``).
+- ``ut`` — upper-tail dependent families (``gumbel``, ``joe``,
+  ``bb1``, ``bb6``, ``bb7``, ``bb8``, ``tawn``).
+- ``rotationless`` — families that already cover positive and negative
+  dependence and therefore have no rotation
+  (``indep``, ``gaussian``, ``student``, ``frank``, ``tll``).
+
+See also
+--------
+:class:`pyvinecopulib.core.Bicop`
+    Bivariate copula model. Its ``family`` attribute is a
+    :class:`BicopFamily` value.
+:class:`pyvinecopulib.core.FitControlsBicop`,
+:class:`pyvinecopulib.core.FitControlsVinecop`
+    Their ``family_set`` argument accepts any of the lists above (or a
+    custom subset).
 """
 
 from ..pyvinecopulib_ext import (

--- a/src/pyvinecopulib/utils/__init__.py
+++ b/src/pyvinecopulib/utils/__init__.py
@@ -1,4 +1,36 @@
-"""Utilities: KDE, dependence measures, sequences, pseudo-obs, plotting."""
+"""Utility primitives used alongside the core copula classes.
+
+This subpackage groups the supporting functionality that copula
+modelling typically needs but that doesn't fit inside the
+:class:`pyvinecopulib.core.Bicop` / :class:`pyvinecopulib.core.Vinecop`
+classes themselves:
+
+- **Univariate kernel density estimation** — :class:`Kde1d` is a
+  boundary-corrected 1d KDE with built-in support for continuous and
+  discrete margins. It is the marginal estimator used internally by
+  :class:`pyvinecopulib.sklearn.VineDensity` /
+  :class:`pyvinecopulib.sklearn.VineRegressor` and is reusable
+  standalone for any 1d density problem.
+- **Pseudo-observations** — :func:`to_pseudo_obs` rank-transforms a
+  data matrix into the unit hypercube, the canonical input shape for
+  fitting copulas.
+- **Dependence measures** — :func:`wdm` computes weighted versions of
+  Kendall's :math:`\\tau`, Spearman's :math:`\\rho`, Pearson, etc.
+- **Low-discrepancy sequences** — :func:`sobol`, :func:`ghalton`, and
+  :func:`simulate_uniform` (the high-level driver) produce
+  quasi-random uniform points used by Monte-Carlo evaluation of
+  copula CDFs and by random vine-structure generation.
+- **Plotting helper** — :func:`pairs_copula_data` produces a
+  pair-plot of a copula sample or a fitted :class:`Vinecop`.
+- **Benchmarking** — :func:`benchmark` runs a quick comparison of
+  available pair-copula families on synthetic data; convenient for
+  smoke-testing a fresh install.
+
+Most users reach for these via :mod:`pyvinecopulib.sklearn` rather
+than calling them directly. The ``examples/07_kde1d.ipynb`` and
+``examples/06_weighted_dependence_measures.ipynb`` notebooks demo
+:class:`Kde1d` and :func:`wdm` in isolation.
+"""
 
 from ..pyvinecopulib_ext import (
   Kde1d,


### PR DESCRIPTION
Three docs-side changes plus one stub-generator fix:

- src/include/bicop/family.hpp: the BicopFamily enum docstring used to contain the entire family taxonomy and the family-group constants (parametric / elliptical / archimedean / ...). The groups belong with the module, not with the enum identifier. Trimmed the enum docstring to the 13 family members + a pointer to the module page.

- src/pyvinecopulib/families/__init__.py: rewrote the module docstring into a proper landing page — one-paragraph intro, taxonomy grouped by mathematical class (Independence / Elliptical / Archimedean / BB / Extreme-value / Nonparametric), and the named family-group constants with their members. Mirrors the rvinecopulib R docs layout.

- src/pyvinecopulib/{core,utils}/__init__.py: replaced the one-line module docstrings with structured overviews. Core: "when to use what" between Bicop / Vinecop / RVineStructure + FitControlsVinecop. Utils: a short paragraph per utility area (Kde1d, to_pseudo_obs, wdm, sobol/ghalton/simulate_uniform, pairs_copula_data, benchmark) with pointers to the relevant example notebooks.

- docs/conf.py: free functions now render the same way as classes — an `.. autosummary:: :toctree: _generate` table on the module landing page, with one detail page per function under `_generate/`. Previously they were dumped inline via `.. autofunction::`, which produced 19-27-line docstrings on the module page and made navigation noisy. Matches the sklearn.metrics-style layout.

Pre-existing stub-generator bug surfaced during local rebuild: the old `.*?` ndarray regex in scripts/generate_stubs.py mangled deeply nested annotations like `tuple[Figure, numpy.ndarray[tuple[Any], numpy.dtype[typing.Any]]]` into syntactically-invalid stubs with trailing `]` and unimported `numpy.dtype`. Ported the nested-bracket-aware regex from feature/sklearn-estimators.

Sphinx -W clean, 111 tests pass, ty clean. Spot-checked: features.html families section now lists the taxonomy + groups; BicopFamily detail page is focused on the enum members; _generate/pyvinecopulib.utils.*.html exists for each of the seven free functions.