### PR TITLE
Integrate VDC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,55 @@
 
 ## Unreleased
 
+### `pyvinecopulib.torch`: pluggable bicop fitters via `FitControlsTorchBicop`
+
+`TorchBicop.from_data` now dispatches on a `FitControlsTorchBicop`
+dataclass (mirroring `pv.FitControlsBicop`), opening the door to
+alternative bicop fitters behind a single API. Two methods ship today:
+
+- `method="tll"` (default) — the existing pure-torch TLL constant fit,
+  unchanged in behaviour and still matching the C++ TLL fit to machine
+  precision.
+- `method="vdc"` — Kempner Institute's
+  [vine-denoising-copula](https://github.com/KempnerInstitute/vine-denoising-copula)
+  pretrained denoiser / diffusion estimator (arXiv 2604.20568). vdc is
+  not on PyPI yet; the `[vdc]` extra resolves it from GitHub via
+  `[tool.uv.sources]` (`uv sync --extra vdc`). Plain pip users install
+  with
+  `pip install "vine-denoising-copula @ git+https://github.com/KempnerInstitute/vine-denoising-copula"`.
+  The resulting `TorchBicop` reuses the standard interpolation-grid
+  evaluation chain, so `pdf` / `cdf` / `hfunc` / `hinv` / `simulate` are
+  identical to the TLL path.
+  > **Upstream status**: vdc 0.1.0 on `main` ships an incomplete wheel —
+  > `vdc.load_pretrained_model` references `vdc.inference` /
+  > `vdc.vine.copula_diffusion` (not packaged). We ship a `sys.modules`
+  > shim in `pyvinecopulib.torch._fit_vdc._install_upstream_shims` that
+  > injects the two missing submodules with trivial stubs (the real
+  > `scatter_to_hist` from `vdc.data.hist` is loaded directly via
+  > `importlib.util`; `sample_density_grid` is stubbed since it's only
+  > used in the diffusion-checkpoint path; `DiffusionCopulaModel` is
+  > stubbed since it's import-referenced but never instantiated during
+  > inference). The shim is installed at the first
+  > `_load_bundle(...)` call and becomes a no-op once upstream restores
+  > the missing subpackages.
+  >
+  > **Released-checkpoint accuracy caveat**: on the standard
+  > Gaussian/Clayton precision bench (m=64, n ∈ {500, 2000, 10000}), the
+  > `vdc-denoiser-m64-v1` checkpoint produces 10–20× worse pdf IAE than
+  > the pure-torch TLL fit, with massive density spikes at the
+  > anti-diagonal corners even for iid uniform samples (mean |pdf - 1| ≈
+  > 0.9). The integration is correct and ready to use, but for parametric
+  > targets TLL remains the better choice today.
+
+The signature change is **breaking** for callers who passed `grid_size`,
+`mult`, or `grid_type` as keyword arguments to `from_data`: those now
+live on `FitControlsTorchBicop(...)`. `cache_integrals`, `device`, and
+`dtype` remain direct keyword arguments on `from_data`.
+
+`InterpolationGrid2D.normalize_margins` additionally accepts an optional
+`tol` for early-stop (default `None` preserves byte-for-byte parity with
+the C++ TLL pipeline).
+
 ### `pyvinecopulib.torch`: align `TorchVinecop` / `TorchBicop` with their `pv.Vinecop` / `pv.Bicop` counterparts
 
 The torch evaluators now mirror the post-fit surface of the C++ classes

--- a/examples/10_torch_backend.ipynb
+++ b/examples/10_torch_backend.ipynb
@@ -26,7 +26,7 @@
     "import matplotlib.pyplot as plt\n",
     "\n",
     "import pyvinecopulib as pv\n",
-    "from pyvinecopulib.torch import TorchBicop, TorchVinecop\n",
+    "from pyvinecopulib.torch import FitControlsTorchBicop, TorchBicop, TorchVinecop\n",
     "\n",
     "torch.set_num_threads(1)\n",
     "rng = np.random.default_rng(42)"
@@ -92,8 +92,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bc_normal = TorchBicop.from_data(u_fit_t, grid_type=\"normal\")\n",
-    "bc_linear = TorchBicop.from_data(u_fit_t, grid_type=\"linear\")\n",
+    "bc_normal = TorchBicop.from_data(\n",
+    "  u_fit_t, FitControlsTorchBicop(grid_type=\"normal\")\n",
+    ")\n",
+    "bc_linear = TorchBicop.from_data(\n",
+    "  u_fit_t, FitControlsTorchBicop(grid_type=\"linear\")\n",
+    ")\n",
     "\n",
     "u1, u2 = torch.meshgrid(\n",
     "  torch.linspace(0.02, 0.98, 80, dtype=torch.float64),\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,14 @@ sklearn = [
 torch = [
   "torch>=2.0",
 ]
+vdc = [
+  "torch>=2.0",
+  # vine-denoising-copula is not on PyPI yet; see [tool.uv.sources] below
+  # for the dev-time GitHub source. End users on plain pip should install
+  # it directly:
+  #   pip install "vine-denoising-copula @ git+https://github.com/KempnerInstitute/vine-denoising-copula"
+  "vine-denoising-copula",
+]
 doc = [
   "sphinx==7.0",
   "nbsphinx==0.9.2",
@@ -94,6 +102,13 @@ Homepage = "https://github.com/vinecopulib/pyvinecopulib/"
 Documentation = "https://pyvinecopulib.readthedocs.io"
 Repository = "https://github.com/vinecopulib/pyvinecopulib.git"
 Issues = "https://github.com/vinecopulib/pyvinecopulib/issues"
+
+[tool.uv.sources]
+# vine-denoising-copula is not yet published to PyPI. Map the bare
+# requirement (from [project.optional-dependencies].vdc) to the GitHub
+# repo so `uv sync --extra vdc` works locally. Remove this entry once
+# the upstream publishes a PyPI release.
+vine-denoising-copula = { git = "https://github.com/KempnerInstitute/vine-denoising-copula" }
 
 [tool.scikit-build]
 minimum-version = "0.4"

--- a/scripts/bench_torch_bicop_fit.py
+++ b/scripts/bench_torch_bicop_fit.py
@@ -1,25 +1,30 @@
 #!/usr/bin/env python
-"""Bench TorchBicop / pv.Bicop on the TLL constant family.
+"""Bench TorchBicop / pv.Bicop bicop fitters on a shared Gaussian sample.
 
 Two modes selected via ``--mode``:
 
 * ``fit`` (default) — time the from_data fit:
     - simulate n pseudo-obs via a Gaussian copula,
     - time ``pv.Bicop.from_data`` with TLL family per thread count,
-    - time ``TorchBicop.from_data`` per device and grid_type.
+    - time ``TorchBicop.from_data`` per device and grid_type (TLL),
+    - (optional) time ``TorchBicop.from_data(method="vdc")`` per device
+      when the ``vine-denoising-copula`` package is installed.
   Output columns:
-    mode, n, backend, threads, device, grid_type, time_ms
+    mode, n, backend, threads, device, grid_type, grid_size, time_ms
 
 * ``eval`` — fit once, time the eval ops (pdf, cdf, hfunc1, hfunc2,
   hinv1, hinv2) on a separate ``n_eval`` sample:
-    - C++ baseline: same fit, no grid_type axis (TLL only has normal).
-    - Torch sweep: device x grid_type x cache_integrals.
+    - C++ baseline: fit at each requested grid_size; no grid_type axis
+      (TLL only has the Phi-spaced grid in C++).
+    - Torch sweep: device x grid_type x grid_size x cache_integrals.
+    - VDC sweep: device x cache_integrals (grid_type fixed to
+      ``"cell-centers"``; grid_size fixed at 64 by the pretrained model).
   Output columns:
     mode, op, n_fit, n_eval, backend, threads, device,
-    cache_integrals, grid_type, time_ms
+    cache_integrals, grid_type, grid_size, time_ms
 
 For ``cpp`` rows, ``device`` / ``cache_integrals`` / ``grid_type`` are
-empty. For ``torch`` rows, ``threads`` is empty.
+empty. For ``torch`` / ``vdc`` rows, ``threads`` is empty.
 """
 
 from __future__ import annotations
@@ -34,7 +39,14 @@ import numpy as np
 import torch
 
 import pyvinecopulib as pv
-from pyvinecopulib.torch import TorchBicop
+from pyvinecopulib.torch import FitControlsTorchBicop, TorchBicop
+
+try:
+  import vdc as _vdc  # noqa: F401
+
+  _HAS_VDC = True
+except ImportError:
+  _HAS_VDC = False
 
 
 def _parse_int_list(s: str) -> list[int]:
@@ -88,38 +100,93 @@ def _time_repeats(fn, repeats: int, sync=None) -> float:
 # --------------------------------------------------------------------------- #
 
 
+_VDC_PRETRAINED_GRID_SIZE = 64  # vdc-denoiser-m64-v1
+
+
 def _bench_fit(
   n: int,
   threads: list[int],
   devices: list[str],
   grid_types: list[str],
+  grid_sizes: list[int],
+  backends: list[str],
   repeats: int,
   seed: int,
 ) -> list[dict]:
   u_np = _simulate(n=n, seed=seed)
   rows: list[dict] = []
 
-  for t in threads:
-    ctl = pv.FitControlsBicop(family_set=[pv.families.tll], num_threads=t)
-    ms = _time_repeats(lambda: pv.Bicop.from_data(u_np, controls=ctl), repeats)
-    rows.append(
-      {
-        "mode": "fit",
-        "n": n,
-        "backend": "cpp",
-        "threads": t,
-        "device": "",
-        "grid_type": "",
-        "time_ms": ms,
-      }
-    )
+  if "cpp" in backends:
+    for t in threads:
+      for g in grid_sizes:
+        ctl = pv.FitControlsBicop(
+          family_set=[pv.families.tll],
+          num_threads=t,
+          nonparametric_grid_size=g,
+        )
+        ms = _time_repeats(
+          lambda c=ctl: pv.Bicop.from_data(u_np, controls=c), repeats
+        )
+        rows.append(
+          {
+            "mode": "fit",
+            "n": n,
+            "backend": "cpp",
+            "threads": t,
+            "device": "",
+            "grid_type": "",
+            "grid_size": g,
+            "time_ms": ms,
+          }
+        )
 
-  for device in devices:
-    sync = torch.cuda.synchronize if device.startswith("cuda") else None
-    u_t = torch.from_numpy(u_np).to(device)
-    for grid_type in grid_types:
+  if "torch" in backends:
+    for device in devices:
+      sync = torch.cuda.synchronize if device.startswith("cuda") else None
+      u_t = torch.from_numpy(u_np).to(device)
+      for grid_type in grid_types:
+        for g in grid_sizes:
+          ctl_torch = FitControlsTorchBicop(grid_type=grid_type, grid_size=g)
+          ms = _time_repeats(
+            lambda u=u_t, c=ctl_torch: TorchBicop.from_data(u, c),
+            repeats,
+            sync=sync,
+          )
+          rows.append(
+            {
+              "mode": "fit",
+              "n": n,
+              "backend": "torch",
+              "threads": "",
+              "device": device,
+              "grid_type": grid_type,
+              "grid_size": g,
+              "time_ms": ms,
+            }
+          )
+
+  if "vdc" in backends and _HAS_VDC:
+    # Pre-warm the bundle cache so HuggingFace download / first model
+    # load is excluded from the timed window. Catch upstream-broken vdc
+    # builds (missing vdc.inference / vdc.vine submodules) and skip
+    # gracefully — same gate as tests/test_torch_bicop_vdc.py.
+    from pyvinecopulib.torch._fit_vdc import _load_bundle
+
+    ctl_vdc = FitControlsTorchBicop(method="vdc")
+    for device in devices:
+      sync = torch.cuda.synchronize if device.startswith("cuda") else None
+      try:
+        _load_bundle(ctl_vdc.vdc_model_id, device)
+      except ModuleNotFoundError as e:
+        print(
+          f"# WARNING: vdc backend unavailable on device={device} due to "
+          f"upstream packaging issue ({e}); skipping.",
+          file=sys.stderr,
+        )
+        continue
+      u_t = torch.from_numpy(u_np).to(device)
       ms = _time_repeats(
-        lambda u=u_t, g=grid_type: TorchBicop.from_data(u, grid_type=g),
+        lambda u=u_t, c=ctl_vdc, d=device: TorchBicop.from_data(u, c, device=d),
         repeats,
         sync=sync,
       )
@@ -127,10 +194,11 @@ def _bench_fit(
         {
           "mode": "fit",
           "n": n,
-          "backend": "torch",
+          "backend": "vdc",
           "threads": "",
           "device": device,
-          "grid_type": grid_type,
+          "grid_type": "cell-centers",
+          "grid_size": _VDC_PRETRAINED_GRID_SIZE,
           "time_ms": ms,
         }
       )
@@ -151,7 +219,9 @@ def _bench_eval(
   threads: list[int],
   devices: list[str],
   grid_types: list[str],
+  grid_sizes: list[int],
   caches: list[bool],
+  backends: list[str],
   repeats: int,
   seed: int,
 ) -> list[dict]:
@@ -160,37 +230,93 @@ def _bench_eval(
   u_eval_np = rng.uniform(0.05, 0.95, size=(n_eval, 2))
   rows: list[dict] = []
 
-  # C++ baseline: fit once per thread count (the threading affects fit, not
-  # eval), then time eval ops. TLL only has the Phi-spaced grid in C++.
-  for t in threads:
-    ctl = pv.FitControlsBicop(family_set=[pv.families.tll], num_threads=t)
-    cop = pv.Bicop.from_data(u_fit_np, controls=ctl)
-    for op in _EVAL_OPS:
-      cpp_fn = getattr(cop, op)
-      ms = _time_repeats(lambda fn=cpp_fn: fn(u_eval_np), repeats)
-      rows.append(
-        {
-          "mode": "eval",
-          "op": op,
-          "n_fit": n_fit,
-          "n_eval": n_eval,
-          "backend": "cpp",
-          "threads": t,
-          "device": "",
-          "cache_integrals": "",
-          "grid_type": "",
-          "time_ms": ms,
-        }
-      )
+  # C++ baseline: fit once per (thread, grid_size); threading affects fit, not
+  # eval. TLL only has the Phi-spaced grid in C++.
+  if "cpp" in backends:
+    for t in threads:
+      for g in grid_sizes:
+        ctl = pv.FitControlsBicop(
+          family_set=[pv.families.tll],
+          num_threads=t,
+          nonparametric_grid_size=g,
+        )
+        cop = pv.Bicop.from_data(u_fit_np, controls=ctl)
+        for op in _EVAL_OPS:
+          cpp_fn = getattr(cop, op)
+          ms = _time_repeats(lambda fn=cpp_fn: fn(u_eval_np), repeats)
+          rows.append(
+            {
+              "mode": "eval",
+              "op": op,
+              "n_fit": n_fit,
+              "n_eval": n_eval,
+              "backend": "cpp",
+              "threads": t,
+              "device": "",
+              "cache_integrals": "",
+              "grid_type": "",
+              "grid_size": g,
+              "time_ms": ms,
+            }
+          )
 
-  for device in devices:
-    sync = torch.cuda.synchronize if device.startswith("cuda") else None
-    u_fit_t = torch.from_numpy(u_fit_np).to(device)
-    u_eval_t = torch.from_numpy(u_eval_np).to(device)
-    for grid_type in grid_types:
+  if "torch" in backends:
+    for device in devices:
+      sync = torch.cuda.synchronize if device.startswith("cuda") else None
+      u_fit_t = torch.from_numpy(u_fit_np).to(device)
+      u_eval_t = torch.from_numpy(u_eval_np).to(device)
+      for grid_type in grid_types:
+        for g in grid_sizes:
+          for cache in caches:
+            bc = TorchBicop.from_data(
+              u_fit_t,
+              FitControlsTorchBicop(grid_type=grid_type, grid_size=g),
+              cache_integrals=cache,
+            )
+            for op in _EVAL_OPS:
+              torch_fn = getattr(bc, op)
+              ms = _time_repeats(
+                lambda fn=torch_fn, u=u_eval_t: fn(u), repeats, sync=sync
+              )
+              rows.append(
+                {
+                  "mode": "eval",
+                  "op": op,
+                  "n_fit": n_fit,
+                  "n_eval": n_eval,
+                  "backend": "torch",
+                  "threads": "",
+                  "device": device,
+                  "cache_integrals": str(cache).lower(),
+                  "grid_type": grid_type,
+                  "grid_size": g,
+                  "time_ms": ms,
+                }
+              )
+            del bc
+            if sync is not None:
+              torch.cuda.empty_cache()
+
+  if "vdc" in backends and _HAS_VDC:
+    from pyvinecopulib.torch._fit_vdc import _load_bundle
+
+    ctl_vdc = FitControlsTorchBicop(method="vdc")
+    for device in devices:
+      sync = torch.cuda.synchronize if device.startswith("cuda") else None
+      try:
+        _load_bundle(ctl_vdc.vdc_model_id, device)
+      except ModuleNotFoundError as e:
+        print(
+          f"# WARNING: vdc backend unavailable on device={device} due to "
+          f"upstream packaging issue ({e}); skipping.",
+          file=sys.stderr,
+        )
+        continue
+      u_fit_t = torch.from_numpy(u_fit_np).to(device)
+      u_eval_t = torch.from_numpy(u_eval_np).to(device)
       for cache in caches:
         bc = TorchBicop.from_data(
-          u_fit_t, grid_type=grid_type, cache_integrals=cache
+          u_fit_t, ctl_vdc, cache_integrals=cache, device=device
         )
         for op in _EVAL_OPS:
           torch_fn = getattr(bc, op)
@@ -203,11 +329,12 @@ def _bench_eval(
               "op": op,
               "n_fit": n_fit,
               "n_eval": n_eval,
-              "backend": "torch",
+              "backend": "vdc",
               "threads": "",
               "device": device,
               "cache_integrals": str(cache).lower(),
-              "grid_type": grid_type,
+              "grid_type": "cell-centers",
+              "grid_size": _VDC_PRETRAINED_GRID_SIZE,
               "time_ms": ms,
             }
           )
@@ -258,10 +385,25 @@ def main() -> None:
     help="TorchBicop grid types to sweep (default: normal,linear).",
   )
   ap.add_argument(
+    "--grid-sizes",
+    default="30,64",
+    type=_parse_int_list,
+    help=(
+      "Density-grid sizes to sweep for cpp/torch (default: 30,64). "
+      "vdc is fixed at 64 by the pretrained model."
+    ),
+  )
+  ap.add_argument(
     "--cache",
     default="false,true",
     type=_parse_bool_list,
     help="cache_integrals values to sweep (eval mode only; default false,true).",
+  )
+  ap.add_argument(
+    "--backends",
+    default="cpp,torch,vdc",
+    type=_parse_str_list,
+    help="Backends to bench (default: cpp,torch,vdc).",
   )
   ap.add_argument("--repeats", default=3, type=int)
   ap.add_argument("--seed", default=42, type=int)
@@ -278,6 +420,15 @@ def main() -> None:
     )
     devices = [d for d in devices if not d.startswith("cuda")]
 
+  backends = list(args.backends)
+  if "vdc" in backends and not _HAS_VDC:
+    print(
+      "# WARNING: vdc not installed; skipping vdc backend "
+      "(install with `pip install pyvinecopulib[vdc]`).",
+      file=sys.stderr,
+    )
+    backends = [b for b in backends if b != "vdc"]
+
   if args.mode == "fit":
     fieldnames = [
       "mode",
@@ -286,6 +437,7 @@ def main() -> None:
       "threads",
       "device",
       "grid_type",
+      "grid_size",
       "time_ms",
     ]
   else:
@@ -299,6 +451,7 @@ def main() -> None:
       "device",
       "cache_integrals",
       "grid_type",
+      "grid_size",
       "time_ms",
     ]
 
@@ -314,6 +467,8 @@ def main() -> None:
         threads=args.threads,
         devices=devices,
         grid_types=args.grid_types,
+        grid_sizes=args.grid_sizes,
+        backends=backends,
         repeats=args.repeats,
         seed=args.seed,
       )
@@ -324,7 +479,9 @@ def main() -> None:
         threads=args.threads,
         devices=devices,
         grid_types=args.grid_types,
+        grid_sizes=args.grid_sizes,
         caches=args.cache,
+        backends=backends,
         repeats=args.repeats,
         seed=args.seed,
       )

--- a/scripts/bench_torch_precision.py
+++ b/scripts/bench_torch_precision.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 """Precision-vs-truth benchmark for the torch backend.
 
-Section 1 — Bicop precision. For each (family, params, n):
+Section 1 — Bicop precision. For each (family, params, n, method):
   - sample u_true ~ cop_true.simulate(n) from the parametric family,
-  - fit two TorchBicops on u_true: one with cache_integrals=False, one
-    with cache_integrals=True,
+  - fit two TorchBicops on u_true (cache_integrals=False vs True) using
+    the requested fitter (``method="tll"`` or ``"vdc"``),
   - on M=10k iid eval points in [0.02, 0.98]^2 compute the integrated
     absolute error (IAE = mean |fit - true|) for pdf, cdf, hfunc1,
     hfunc2, hinv1, hinv2, where "true" comes from the parametric
@@ -19,7 +19,8 @@ Section 2 — Vine precision. For each d:
   - compute IAE = mean |fit.pdf - true.pdf| on M=10k iid points.
 
 Outputs a long-format CSV to --output (default stdout) with columns:
-    section, family, params, d, n, quantity, cache, grid_type, IAE
+    section, family, params, d, n, quantity, cache, method, grid_type,
+    grid_size, IAE
 """
 
 from __future__ import annotations
@@ -32,7 +33,14 @@ import numpy as np
 import torch
 
 import pyvinecopulib as pv
-from pyvinecopulib.torch import TorchBicop, TorchVinecop
+from pyvinecopulib.torch import FitControlsTorchBicop, TorchBicop, TorchVinecop
+
+try:
+  import vdc as _vdc  # noqa: F401
+
+  _HAS_VDC = True
+except ImportError:
+  _HAS_VDC = False
 
 
 # --- shared helpers ------------------------------------------------------ #
@@ -79,8 +87,16 @@ def _bicop_fit(bc: TorchBicop, u_t: torch.Tensor) -> dict[str, np.ndarray]:
   }
 
 
+_VDC_PRETRAINED_GRID_SIZE = 64  # vdc-denoiser-m64-v1
+
+
 def _run_bicop_section(
-  n_list: list[int], grid_types: list[str], m_eval: int, seed: int
+  n_list: list[int],
+  grid_types: list[str],
+  grid_sizes: list[int],
+  methods: list[str],
+  m_eval: int,
+  seed: int,
 ) -> list[dict]:
   rows: list[dict] = []
   rng_master = np.random.default_rng(seed)
@@ -97,28 +113,44 @@ def _run_bicop_section(
       u_eval_t = torch.from_numpy(u_eval)
 
       truths = _bicop_truth(cop_true, u_eval)
-      for grid_type in grid_types:
-        for cache in (False, True):
-          bc_fit = TorchBicop.from_data(
-            torch.from_numpy(u_true),
-            cache_integrals=cache,
-            grid_type=grid_type,
-          )
-          fits = _bicop_fit(bc_fit, u_eval_t)
-          for q in truths:
-            rows.append(
-              {
-                "section": "bicop",
-                "family": fam_label,
-                "params": ";".join(f"{p:g}" for p in params),
-                "d": 2,
-                "n": n,
-                "quantity": q,
-                "cache": int(cache),
-                "grid_type": grid_type,
-                "IAE": _iae(fits[q], truths[q]),
-              }
+      for method in methods:
+        if method == "vdc":
+          # vdc ignores grid_type and grid_size — the pretrained model
+          # enforces a 64×64 cell-centered grid.
+          method_configs = [("cell-centers", _VDC_PRETRAINED_GRID_SIZE)]
+        else:
+          method_configs = [(gt, g) for gt in grid_types for g in grid_sizes]
+        for grid_type, grid_size in method_configs:
+          for cache in (False, True):
+            ctl = (
+              FitControlsTorchBicop(method="vdc")
+              if method == "vdc"
+              else FitControlsTorchBicop(
+                method="tll", grid_type=grid_type, grid_size=grid_size
+              )
             )
+            bc_fit = TorchBicop.from_data(
+              torch.from_numpy(u_true),
+              ctl,
+              cache_integrals=cache,
+            )
+            fits = _bicop_fit(bc_fit, u_eval_t)
+            for q in truths:
+              rows.append(
+                {
+                  "section": "bicop",
+                  "family": fam_label,
+                  "params": ";".join(f"{p:g}" for p in params),
+                  "d": 2,
+                  "n": n,
+                  "quantity": q,
+                  "cache": int(cache),
+                  "method": method,
+                  "grid_type": grid_type,
+                  "grid_size": grid_size,
+                  "IAE": _iae(fits[q], truths[q]),
+                }
+              )
       print(
         f"# bicop {fam_label}({params}) n={n} done", file=sys.stderr, flush=True
       )
@@ -186,7 +218,9 @@ def _run_vine_section(
           "d": d,
           "n": n,
           "cache": int(cache),
+          "method": "tll",
           "grid_type": grid_type,
+          "grid_size": 30,  # TorchVinecop.from_data default; not yet swept
         }
         rows.append(
           {**base, "quantity": "pdf", "IAE": _iae(fit_pdf, truth_pdf)}
@@ -255,16 +289,55 @@ def main() -> None:
     default="normal,linear",
     help="Storage-grid types to sweep (default: normal,linear).",
   )
+  ap.add_argument(
+    "--grid-sizes",
+    default="30,64",
+    help=(
+      "TLL density-grid sizes to sweep in the bicop section "
+      "(default: 30,64). vdc is fixed at 64."
+    ),
+  )
+  ap.add_argument(
+    "--methods",
+    default="tll,vdc",
+    help="Bicop fitters to sweep in the bicop section (default: tll,vdc).",
+  )
   ap.add_argument("--output", default="-")
   args = ap.parse_args()
 
   torch.set_num_threads(1)
   sections = {s.strip() for s in args.sections.split(",") if s.strip()}
   grid_types = [g.strip() for g in args.grid_types.split(",") if g.strip()]
+  grid_sizes = [int(g.strip()) for g in args.grid_sizes.split(",") if g.strip()]
+  methods = [m.strip() for m in args.methods.split(",") if m.strip()]
+  if "vdc" in methods:
+    if not _HAS_VDC:
+      print(
+        "# WARNING: vdc not installed; skipping vdc method "
+        "(install with `uv sync --extra vdc`).",
+        file=sys.stderr,
+      )
+      methods = [m for m in methods if m != "vdc"]
+    else:
+      # Probe upstream-broken vdc wheels (missing vdc.inference /
+      # vdc.vine) — try a smoke load and drop vdc if it fails.
+      try:
+        from pyvinecopulib.torch._fit_vdc import _load_bundle
+
+        _load_bundle("vdc-denoiser-m64-v1", "cpu")
+      except ModuleNotFoundError as e:
+        print(
+          f"# WARNING: vdc available but unusable ({e}); skipping vdc "
+          f"method. Wait for upstream to restore vdc.inference / vdc.vine.",
+          file=sys.stderr,
+        )
+        methods = [m for m in methods if m != "vdc"]
 
   rows: list[dict] = []
   if "bicop" in sections:
-    rows += _run_bicop_section(args.n_bicop, grid_types, args.m_eval, args.seed)
+    rows += _run_bicop_section(
+      args.n_bicop, grid_types, grid_sizes, methods, args.m_eval, args.seed
+    )
   if "vine" in sections:
     rows += _run_vine_section(
       args.d_vine, grid_types, args.n_vine, args.m_eval, args.seed + 1
@@ -281,7 +354,9 @@ def main() -> None:
       "n",
       "quantity",
       "cache",
+      "method",
       "grid_type",
+      "grid_size",
       "IAE",
     ],
   )

--- a/src/pyvinecopulib/torch/__init__.py
+++ b/src/pyvinecopulib/torch/__init__.py
@@ -1,13 +1,17 @@
 """PyTorch backend for the TLL / kernel bivariate and vine copulas.
 
 This subpackage mirrors :mod:`pyvinecopulib.core`'s evaluation chain in
-pure PyTorch. It exposes three classes:
+pure PyTorch. It exposes:
 
-* :class:`TorchBicop` — a ``torch.nn.Module`` evaluator for a single TLL
-  pair copula. Built either from a fitted :class:`pyvinecopulib.Bicop`
-  (:meth:`TorchBicop.from_bicop`) or directly from data via a pure-torch
-  TLL fit (:meth:`TorchBicop.from_data`). Exposes ``pdf`` / ``cdf`` /
-  ``hfunc1`` / ``hfunc2`` / ``hinv1`` / ``hinv2`` / ``sample``.
+* :class:`TorchBicop` — a ``torch.nn.Module`` evaluator for a single
+  bivariate pair copula on a density grid. Built either from a fitted
+  :class:`pyvinecopulib.Bicop` (:meth:`TorchBicop.from_bicop`) or
+  directly from data via :meth:`TorchBicop.from_data` (which dispatches
+  on :class:`FitControlsTorchBicop` — pure-torch TLL by default;
+  ``method="vdc"`` plugs in the optional `vine-denoising-copula
+  <https://github.com/KempnerInstitute/vine-denoising-copula>`_
+  pretrained estimator). Exposes ``pdf`` / ``cdf`` / ``hfunc1`` /
+  ``hfunc2`` / ``hinv1`` / ``hinv2`` / ``simulate``.
 
 * :class:`TorchVinecop` — a ``torch.nn.Module`` evaluator for an R-vine
   built on top of :class:`TorchBicop` pair copulas. Provides ``pdf`` /
@@ -16,6 +20,11 @@ pure PyTorch. It exposes three classes:
   (``impl="legacy"``, byte-for-byte agreement with
   :class:`pyvinecopulib.Vinecop`) and a dict-based reformulation
   (``impl="lazy"``) following Cheng, Vatter, Nagler & Chen (2025).
+
+* :class:`FitControlsTorchBicop` — fit-time controls for
+  :meth:`TorchBicop.from_data`. Mirrors
+  :class:`pyvinecopulib.FitControlsBicop`; carries the ``method``
+  selector plus method-specific parameters.
 
 * :class:`InterpolationGrid2D` — the underlying bilinear-interpolation
   grid (re-exported for advanced users). Provides static factories for
@@ -34,6 +43,15 @@ References
 Installation
 ------------
 Requires PyTorch. Install with ``pip install pyvinecopulib[torch]``.
+
+The optional ``method="vdc"`` path additionally requires the
+`vine-denoising-copula
+<https://github.com/KempnerInstitute/vine-denoising-copula>`_ package,
+which is not yet on PyPI. The ``[vdc]`` extra resolves it from GitHub
+via ``[tool.uv.sources]`` for uv users (``uv sync --extra vdc``); for
+plain pip, install directly::
+
+    pip install "vine-denoising-copula @ git+https://github.com/KempnerInstitute/vine-denoising-copula"
 """
 
 try:
@@ -47,5 +65,11 @@ except ImportError as e:
 from .bicop import TorchBicop
 from .vinecop import TorchVinecop
 from ._interp import InterpolationGrid2D
+from ._controls import FitControlsTorchBicop
 
-__all__ = ["TorchBicop", "TorchVinecop", "InterpolationGrid2D"]
+__all__ = [
+  "TorchBicop",
+  "TorchVinecop",
+  "InterpolationGrid2D",
+  "FitControlsTorchBicop",
+]

--- a/src/pyvinecopulib/torch/_controls.py
+++ b/src/pyvinecopulib/torch/_controls.py
@@ -1,0 +1,84 @@
+"""Fit-time controls for :class:`TorchBicop`.
+
+Mirrors :class:`pyvinecopulib.FitControlsBicop`: method-specific args live
+on this dataclass; cross-cutting args (``cache_integrals`` / ``device`` /
+``dtype``) stay on :meth:`TorchBicop.from_data`. Adding a new fitter to
+the torch backend only requires extending this dataclass and the dispatch
+in :meth:`TorchBicop.from_data` — the public ``from_data`` signature is
+forward-stable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+METHODS: tuple[str, ...] = ("tll", "vdc")
+
+
+@dataclass
+class FitControlsTorchBicop:
+  """Controls for :meth:`TorchBicop.from_data`.
+
+  Parameters
+  ----------
+  method:
+    Which fitter to use. ``"tll"`` (default) is the pure-torch TLL KDE
+    that matches the C++ ``pv.Bicop.from_data(u, family_set=[tll])`` fit
+    to machine precision. ``"vdc"`` is the Kempner Institute's
+    `vine-denoising-copula
+    <https://github.com/KempnerInstitute/vine-denoising-copula>`_
+    pretrained denoiser / diffusion estimator (arXiv 2604.20568). vdc
+    is not on PyPI yet; install via the ``[vdc]`` extra under uv
+    (``uv sync --extra vdc``) or with pip directly:
+    ``pip install "vine-denoising-copula @ git+https://github.com/KempnerInstitute/vine-denoising-copula"``.
+  grid_size:
+    *TLL only.* Density grid size per axis (default ``30``; matches C++).
+  mult:
+    *TLL only.* Bandwidth multiplier (default ``1.0``; matches C++).
+  grid_type:
+    *TLL only.* Storage grid type — ``"normal"`` (default, Phi-spaced,
+    byte-for-byte parity with C++) or ``"linear"`` (uniform on ``[0, 1]``
+    with the O(1) cell-finding fast-path in
+    :meth:`InterpolationGrid2D._cell_index`).
+  vdc_bundle:
+    *VDC only.* A pre-loaded ``vdc.LoadedPretrainedModel``. If ``None``,
+    the loader is invoked with ``vdc_model_id`` and the result is cached
+    at module scope (keyed on model_id × device) so repeated fits
+    amortize the HuggingFace download.
+  vdc_model_id:
+    *VDC only.* Pretrained checkpoint identifier (default
+    ``"vdc-denoiser-m64-v1"``; ``m=64`` density grid).
+  vdc_diffusion_steps:
+    *VDC only.* DDIM step count for diffusion checkpoints. ``None``
+    (default) lets vdc pick its own; ignored for the denoiser
+    checkpoint, which is a single forward pass.
+  vdc_cfg_scale:
+    *VDC only.* Classifier-free guidance scale for diffusion checkpoints
+    (default ``1.0``); ignored for the denoiser checkpoint.
+  vdc_projection_iters:
+    *VDC only.* IPFP / Sinkhorn iterations enforcing uniform marginals
+    on the cell-center grid (default ``50``). With this many iterations
+    vdc's output is already at machine-precision uniform marginals, so
+    the resulting :class:`TorchBicop` is built with ``norm_times=0``.
+  """
+
+  method: str = "tll"
+
+  # TLL-only
+  grid_size: int = 30
+  mult: float = 1.0
+  grid_type: str = "normal"
+
+  # VDC-only
+  vdc_bundle: Optional[Any] = None
+  vdc_model_id: str = "vdc-denoiser-m64-v1"
+  vdc_diffusion_steps: Optional[int] = None
+  vdc_cfg_scale: float = 1.0
+  vdc_projection_iters: int = 50
+
+  def __post_init__(self) -> None:
+    if self.method not in METHODS:
+      raise ValueError(
+        f"unknown method={self.method!r}; expected one of {METHODS}"
+      )

--- a/src/pyvinecopulib/torch/_fit_vdc.py
+++ b/src/pyvinecopulib/torch/_fit_vdc.py
@@ -1,0 +1,246 @@
+"""vdc-based fitter for :class:`TorchBicop`.
+
+Wraps the Kempner Institute's `vine-denoising-copula
+<https://github.com/KempnerInstitute/vine-denoising-copula>`_ pretrained
+estimator (arXiv 2604.20568): vdc takes a ``(n, 2)`` pseudo-observation
+sample and produces an ``(m, m)`` density grid on the cell-centered
+grid ``(0.5/m, 1.5/m, …, (m-0.5)/m)``. We replicate-pad that grid to
+``(m+2, m+2)`` on ``[0, cell-centers..., 1]`` and hand it to the existing
+:class:`InterpolationGrid2D`, which then provides ``pdf`` / ``cdf`` /
+``hfunc`` / ``hinv`` / sampling exactly as for the TLL fit.
+
+Why replicate-pad works: vdc's ``copula_project`` IPFP enforces
+midpoint-rule uniform marginals on the cell-center grid (``sum_i
+density[i, j] * (1/m) = 1``). The trapezoidal integral of the
+replicate-padded density on ``[0, 1]`` coincides with that midpoint sum
+at every cell center, so marginals stay uniform without re-running
+``normalize_margins`` and the h-function values at cell centers match
+vdc's ``(cumsum - 0.5*density) * (1/m)`` formula exactly.
+
+The ``vdc`` package is imported lazily so ``pyvinecopulib.torch``
+imports cleanly without it. With ``uv``, install via the ``[vdc]``
+extra (pyvinecopulib's ``pyproject.toml`` maps it to the GitHub repo
+through ``[tool.uv.sources]``)::
+
+    uv sync --extra vdc                  # in a pyvinecopulib checkout
+    uv pip install "pyvinecopulib[vdc]"  # from an arbitrary uv project
+
+Plain pip doesn't read ``[tool.uv.sources]``, so install vdc directly::
+
+    pip install "vine-denoising-copula @ git+https://github.com/KempnerInstitute/vine-denoising-copula"
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Optional
+
+import torch
+from torch import Tensor
+
+if TYPE_CHECKING:  # pragma: no cover
+  from ._controls import FitControlsTorchBicop
+
+# (model_id, device-str) -> LoadedPretrainedModel.
+_BUNDLE_CACHE: dict[tuple[str, str], Any] = {}
+
+
+def _try_import_vdc():
+  """Lazy-import vine-denoising-copula with a friendly error.
+
+  .. note::
+
+     As of vdc 0.1.0 on GitHub main, the published wheel references
+     several submodules that aren't shipped (``vdc.inference``,
+     ``vdc.vine``). We work around this with a ``sys.modules`` shim
+     installed by :func:`_install_upstream_shims` before the first
+     :func:`vdc.load_pretrained_model` call — see that function for the
+     details. Once upstream restores the missing subpackages the shim
+     detects them and becomes a no-op.
+  """
+  try:
+    import vdc as _vdc
+  except (
+    ImportError
+  ) as e:  # pragma: no cover - exercised in tests via monkeypatch
+    raise ImportError(
+      "method='vdc' requires the vine-denoising-copula package, which "
+      "is not yet on PyPI. Install with `uv sync --extra vdc` (uses the "
+      "GitHub source declared in pyproject.toml's [tool.uv.sources]) or "
+      "with pip directly:\n"
+      '    pip install "vine-denoising-copula @ '
+      'git+https://github.com/KempnerInstitute/vine-denoising-copula"'
+    ) from e
+  return _vdc
+
+
+_SHIMMED = False
+
+
+def _install_upstream_shims() -> None:
+  """Work around the vdc 0.1.0 upstream packaging bug.
+
+  As shipped on GitHub ``main``, the vdc wheel references two submodules
+  that aren't actually packaged:
+
+  - ``vdc.inference.density`` (imported by ``vdc.data.onthefly`` for
+    ``scatter_to_hist`` — the real function lives in ``vdc.data.hist`` —
+    and also referenced inside ``vdc.pretrained.estimate_pair_density_from_samples``
+    for ``sample_density_grid``, which is only used in the diffusion
+    branch we don't touch).
+  - ``vdc.vine.copula_diffusion`` (imported by ``vdc.data.onthefly`` for
+    ``DiffusionCopulaModel`` — only used at training time, never
+    instantiated during inference).
+
+  Both are referenced at *import time*, so ``vdc.load_pretrained_model``
+  raises ``ModuleNotFoundError`` before doing anything useful. We inject
+  ``sys.modules`` stubs that satisfy the imports without changing
+  inference behaviour. Once upstream restores the missing subpackages
+  this function becomes a no-op (we detect that and skip).
+  """
+  global _SHIMMED
+  if _SHIMMED:
+    return
+  import importlib
+  import importlib.util
+  import sys
+  import types
+
+  # If the real modules are present (post-upstream-fix), do nothing.
+  try:
+    importlib.import_module("vdc.inference.density")
+    importlib.import_module("vdc.vine.copula_diffusion")
+    _SHIMMED = True
+    return
+  except ModuleNotFoundError:
+    pass
+
+  vdc_spec = importlib.util.find_spec("vdc")
+  if vdc_spec is None or vdc_spec.origin is None:
+    _SHIMMED = True
+    return
+  vdc_dir = vdc_spec.origin.rsplit("/", 1)[0]
+
+  # Load ``scatter_to_hist`` from ``vdc/data/hist.py`` directly via the
+  # file-location loader — going through ``import vdc.data.hist`` would
+  # trigger ``vdc/data/__init__.py``'s transitive broken imports.
+  hist_spec = importlib.util.spec_from_file_location(
+    "_vdc_hist_internal", f"{vdc_dir}/data/hist.py"
+  )
+  if hist_spec is None or hist_spec.loader is None:
+    _SHIMMED = True
+    return
+  hist_mod = importlib.util.module_from_spec(hist_spec)
+  hist_spec.loader.exec_module(hist_mod)
+
+  def _missing_sample_density_grid(*args, **kwargs):
+    raise NotImplementedError(
+      "vdc.inference.density.sample_density_grid is missing from the "
+      "installed vdc wheel (upstream packaging bug); diffusion-checkpoint "
+      "inference is unavailable. Use a denoiser checkpoint such as "
+      "'vdc-denoiser-m64-v1' instead."
+    )
+
+  # Use setattr for the dynamic module-attribute writes so the type
+  # checker doesn't flag ModuleType as missing the attributes we're
+  # creating on the fly.
+  inference_pkg = types.ModuleType("vdc.inference")
+  setattr(inference_pkg, "__path__", [])
+  density_mod = types.ModuleType("vdc.inference.density")
+  setattr(density_mod, "scatter_to_hist", getattr(hist_mod, "scatter_to_hist"))
+  setattr(density_mod, "sample_density_grid", _missing_sample_density_grid)
+  sys.modules["vdc.inference"] = inference_pkg
+  sys.modules["vdc.inference.density"] = density_mod
+
+  vine_pkg = types.ModuleType("vdc.vine")
+  setattr(vine_pkg, "__path__", [])
+  cdiff_mod = types.ModuleType("vdc.vine.copula_diffusion")
+
+  class _StubDiffusionCopulaModel:
+    """Stub for an upstream-missing class that's import-referenced but
+    never instantiated during inference."""
+
+    def __init__(self, *args, **kwargs) -> None:
+      pass
+
+  setattr(cdiff_mod, "DiffusionCopulaModel", _StubDiffusionCopulaModel)
+  sys.modules["vdc.vine"] = vine_pkg
+  sys.modules["vdc.vine.copula_diffusion"] = cdiff_mod
+
+  _SHIMMED = True
+
+
+def _load_bundle(model_id: str, device: Optional[torch.device | str]):
+  """Return a cached ``vdc.LoadedPretrainedModel`` for ``model_id`` on ``device``.
+
+  The cache is keyed on ``(model_id, str(device))`` so the same checkpoint
+  loaded on cpu and cuda gives two distinct entries. The HuggingFace
+  download is only paid on the first cache miss per process.
+  """
+  vdc = _try_import_vdc()
+  _install_upstream_shims()
+  key = (model_id, str(device))
+  if key not in _BUNDLE_CACHE:
+    _BUNDLE_CACHE[key] = vdc.load_pretrained_model(
+      model_id, device=device or "cpu"
+    )
+  return _BUNDLE_CACHE[key]
+
+
+def _replicate_pad(density: Tensor) -> tuple[Tensor, Tensor]:
+  """Pad a cell-centered ``(m, m)`` density to a ``(m+2, m+2)`` grid that
+  spans ``[0, 1]``.
+
+  Returns ``(grid_points, padded_values)`` ready for the
+  :class:`TorchBicop` constructor. The padded grid points are
+  ``[0, 0.5/m, 1.5/m, …, (m-0.5)/m, 1]`` (length ``m+2``); padded values
+  replicate the first/last row and column. With this padding the
+  trapezoidal integral on the padded grid equals vdc's midpoint cumsum
+  at every cell center — see this module's docstring for the algebra.
+  """
+  if density.ndim != 2 or density.shape[0] != density.shape[1]:
+    raise ValueError(
+      f"vdc density must be a square 2D array; got shape {tuple(density.shape)}"
+    )
+  m = density.shape[0]
+  cc = (torch.arange(m, dtype=density.dtype, device=density.device) + 0.5) / m
+  grid_points = torch.cat([cc.new_zeros(1), cc, cc.new_ones(1)])
+  padded = (
+    torch.nn.functional.pad(
+      density.unsqueeze(0).unsqueeze(0), (1, 1, 1, 1), mode="replicate"
+    )
+    .squeeze(0)
+    .squeeze(0)
+  )
+  return grid_points, padded
+
+
+def fit_vdc(
+  u: Tensor,
+  controls: "FitControlsTorchBicop",
+  *,
+  device: Optional[torch.device | str],
+  dtype: torch.dtype,
+) -> tuple[Tensor, Tensor]:
+  """Estimate a bivariate density via vdc and return ``(grid_points, values)``.
+
+  ``u`` is an ``(n, 2)`` tensor of pseudo-observations in ``[0, 1]^2``.
+  The returned ``(grid_points, values)`` are sized ``(m+2,)`` and
+  ``(m+2, m+2)`` respectively, where ``m`` is the pretrained model's
+  density-grid resolution (``64`` for ``vdc-denoiser-m64-v1``).
+  """
+  if u.ndim != 2 or u.shape[1] != 2:
+    raise ValueError(f"u must have shape (n, 2); got {tuple(u.shape)}")
+  vdc = _try_import_vdc()
+  bundle = controls.vdc_bundle
+  if bundle is None:
+    bundle = _load_bundle(controls.vdc_model_id, device)
+  u_np = u.detach().cpu().numpy()
+  density_np = vdc.estimate_pair_density_from_samples(
+    bundle,
+    u_np,
+    diffusion_steps=controls.vdc_diffusion_steps,
+    cfg_scale=controls.vdc_cfg_scale,
+    projection_iters=controls.vdc_projection_iters,
+  )
+  density = torch.as_tensor(density_np, dtype=dtype, device=device)
+  return _replicate_pad(density)

--- a/src/pyvinecopulib/torch/_interp.py
+++ b/src/pyvinecopulib/torch/_interp.py
@@ -45,6 +45,7 @@ class InterpolationGrid2D(torch.nn.Module):
     values: Tensor,
     norm_times: int = 3,
     is_linear: bool = False,
+    norm_tol: float | None = None,
   ) -> None:
     super().__init__()
     if values.ndim != 2 or values.shape[0] != values.shape[1]:
@@ -65,7 +66,7 @@ class InterpolationGrid2D(torch.nn.Module):
     # (with the endpoint clamp above leaving it unchanged), so cell-finding is
     # O(1) — ``floor(u * (m - 1))`` — instead of an O(log m) ``searchsorted``.
     self._is_linear = bool(is_linear)
-    self.normalize_margins(norm_times)
+    self.normalize_margins(norm_times, tol=norm_tol)
 
   # --------------------------------------------------------------------- #
   # Grid construction (factories shared by all callers)                    #
@@ -137,11 +138,21 @@ class InterpolationGrid2D(torch.nn.Module):
   # --------------------------------------------------------------------- #
 
   @torch.no_grad()
-  def normalize_margins(self, times: int) -> None:
+  def normalize_margins(self, times: int, tol: float | None = None) -> None:
     """Renormalize ``values`` so both margins integrate to 1.
 
-    Same algorithm as the C++ ``normalize_margins``: alternating row / column
-    trapezoidal-integral divides, repeated ``times`` rounds.
+    Same algorithm as the C++ ``normalize_margins``: alternating row /
+    column trapezoidal-integral divides, repeated up to ``times`` rounds.
+
+    Args:
+      times: maximum number of normalization rounds. ``times=3`` matches
+        the C++ TLL pipeline byte-for-byte.
+      tol: optional convergence tolerance. When provided, iteration stops
+        as soon as the largest absolute deviation of the row+col
+        integrals from 1 drops below ``tol``. Default ``None`` preserves
+        the C++ "fixed-budget" semantics — useful for parity-sensitive
+        callers. Setting e.g. ``tol=1e-9`` together with a generous
+        ``times=50`` reproduces vdc-style IPFP-to-convergence.
     """
     if times <= 0:
       return
@@ -155,6 +166,13 @@ class InterpolationGrid2D(torch.nn.Module):
         (self.values[:-1, :] + self.values[1:, :]) * dgrid.unsqueeze(-1)
       ).sum(dim=0)
       self.values.div_(col_int.clamp_min(1e-20))
+      if tol is not None:
+        err = max(
+          (row_int - 1.0).abs().max().item(),
+          (col_int - 1.0).abs().max().item(),
+        )
+        if err < tol:
+          break
 
   @torch.no_grad()
   def flip(self) -> None:

--- a/src/pyvinecopulib/torch/bicop.py
+++ b/src/pyvinecopulib/torch/bicop.py
@@ -1,19 +1,25 @@
-"""PyTorch ``BiCop`` module — port of the kernel/TLL bivariate copula.
+"""PyTorch ``BiCop`` module — kernel/TLL bivariate copula on a grid.
 
-Consumes the fitted grid from :class:`pyvinecopulib.Bicop` (with the ``tll``
-family). The evaluation chain (``pdf`` / ``cdf`` / ``hfunc`` / ``hinv`` /
-``sample``) lives entirely in PyTorch, so it can be moved to GPU and
-combined with autograd-aware downstream code.
+The evaluation chain (``pdf`` / ``cdf`` / ``hfunc`` / ``hinv`` /
+``simulate``) lives entirely in PyTorch, so it can be moved to GPU and
+composed with autograd-aware downstream code.
 
-Fitting is intentionally not provided here: the underlying TLL kernel
-estimator is computed in the C++ library, and the user is expected to
-construct an instance via :meth:`TorchBicop.from_bicop` after fitting with
-``pv.Bicop(family=tll)``.
+Three constructors are provided:
+
+* :meth:`TorchBicop.from_data` — fit on pseudo-observations directly in
+  PyTorch. Dispatches on the ``method`` field of a
+  :class:`FitControlsTorchBicop`: ``"tll"`` (default, machine-precision
+  parity with the C++ TLL fit) or ``"vdc"`` (vine-denoising-copula
+  pretrained estimator, optional dep).
+* :meth:`TorchBicop.from_bicop` — lift a fitted C++
+  :class:`pyvinecopulib.Bicop` (``tll`` family) into the torch backend.
+* ``TorchBicop(grid_points=..., values=...)`` — construct from an
+  externally-prepared density grid.
 """
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 import torch
 from torch import Tensor
@@ -21,6 +27,9 @@ from torch import Tensor
 from ..pyvinecopulib_ext import Bicop, tll as _TLL_FAMILY
 from ._interp import InterpolationGrid2D, _TRIM_LO, _TRIM_HI
 from ._util import solve_itp
+
+if TYPE_CHECKING:
+  from ._controls import FitControlsTorchBicop
 
 _LOG_FLOOR: float = -13.815510557964274  # log(1e-6); same as torchvinecopulib
 
@@ -172,44 +181,77 @@ class TorchBicop(torch.nn.Module):
   def from_data(
     cls,
     u,
-    grid_size: int = 30,
-    mult: float = 1.0,
+    controls: Optional["FitControlsTorchBicop"] = None,
+    *,
     cache_integrals: bool = False,
-    grid_type: str = "normal",
     device: Optional[torch.device] = None,
     dtype: torch.dtype = torch.float64,
   ) -> "TorchBicop":
-    """Fit a TLL bicop on pseudo-observations and wrap in a ``TorchBicop``.
+    """Fit a bicop on pseudo-observations and wrap in a ``TorchBicop``.
 
-    Pure-PyTorch port of the C++ ``TllBicop::fit`` for the ``constant``
-    method (the C++ default). With ``grid_type="normal"`` the output
-    matches ``pv.Bicop.from_data(u,
-    controls=FitControlsBicop(family_set=[tll]))`` to machine precision
-    (worst case observed: ~1e-12 across (n, ρ) in
-    ``{500, 2000} × {0.3, 0.6, 0.9}``).
+    Dispatches on ``controls.method``:
+
+    * ``"tll"`` (default) — pure-PyTorch port of the C++ ``TllBicop::fit``
+      for the ``constant`` method. With ``grid_type="normal"`` the output
+      matches ``pv.Bicop.from_data(u,
+      controls=FitControlsBicop(family_set=[tll]))`` to machine precision
+      (worst case observed: ~1e-12 across (n, ρ) in
+      ``{500, 2000} × {0.3, 0.6, 0.9}``).
+    * ``"vdc"`` — Kempner Institute's `vine-denoising-copula
+      <https://github.com/KempnerInstitute/vine-denoising-copula>`_
+      pretrained denoiser / diffusion estimator. vdc is not on PyPI yet;
+      install via ``pip install "vine-denoising-copula @
+      git+https://github.com/KempnerInstitute/vine-denoising-copula"``.
+      Raises ``ImportError`` if unavailable. The first call on each
+      ``(model_id, device)`` pair pulls the checkpoint from HuggingFace
+      and caches it in memory.
 
     Args:
       u: ``(n, 2)`` pseudo-observations; np.ndarray or Tensor.
-      grid_size: density grid size per axis (default 30; matches C++).
-      mult: bandwidth multiplier (default 1; matches C++).
-      grid_type: ``"normal"`` (default, matches C++ — Phi-spaced grid) or
-        ``"linear"`` (uniform grid on [0, 1] with O(1) cell-finding at
-        eval time). Both build the KDE on the same z-range so bandwidth
-        selection is unaffected; only the storage grid changes.
-      cache_integrals, device, dtype: same semantics as :meth:`__init__`.
+      controls: :class:`FitControlsTorchBicop` instance specifying the
+        method and method-specific parameters. ``None`` defaults to
+        ``FitControlsTorchBicop()`` (TLL, grid_size=30, normal grid).
+      cache_integrals: see :meth:`__init__`.
+      device, dtype: see :meth:`__init__`.
     """
-    from ._fit_tll import fit_tll_constant
+    from ._controls import FitControlsTorchBicop
+
+    if controls is None:
+      controls = FitControlsTorchBicop()
 
     u_t = torch.as_tensor(u, dtype=dtype, device=device)
-    grid_points, values = fit_tll_constant(
-      u_t, grid_size=grid_size, mult=mult, grid_type=grid_type
-    )
+    if u_t.ndim != 2 or u_t.shape[1] != 2:
+      raise ValueError(f"u must have shape (n, 2); got {tuple(u_t.shape)}")
+
+    if controls.method == "tll":
+      from ._fit_tll import fit_tll_constant
+
+      grid_points, values = fit_tll_constant(
+        u_t,
+        grid_size=controls.grid_size,
+        mult=controls.mult,
+        grid_type=controls.grid_type,
+      )
+      return cls(
+        grid_points=grid_points,
+        values=values,
+        cache_integrals=cache_integrals,
+        norm_times=3,
+        is_linear=(controls.grid_type == "linear"),
+        device=device,
+        dtype=dtype,
+      )
+
+    # method == "vdc" — already validated by FitControlsTorchBicop.__post_init__.
+    from ._fit_vdc import fit_vdc
+
+    grid_points, values = fit_vdc(u_t, controls, device=device, dtype=dtype)
     return cls(
       grid_points=grid_points,
       values=values,
       cache_integrals=cache_integrals,
-      norm_times=3,
-      is_linear=(grid_type == "linear"),
+      norm_times=0,  # vdc's IPFP has already enforced uniform marginals
+      is_linear=False,  # padded grid has 2 half-cells at the boundaries
       device=device,
       dtype=dtype,
     )

--- a/src/pyvinecopulib/torch/vinecop.py
+++ b/src/pyvinecopulib/torch/vinecop.py
@@ -284,9 +284,12 @@ class TorchVinecop(torch.nn.Module):
       u: ``(n, d)`` pseudo-observations; np.ndarray or Tensor.
       structure: :class:`pyvinecopulib.RVineStructure` describing the vine
         skeleton.
-      grid_size, mult, grid_type: forwarded to :meth:`TorchBicop.from_data`.
+      grid_size, mult, grid_type: forwarded to :meth:`TorchBicop.from_data`
+        via a :class:`FitControlsTorchBicop`.
       cache_integrals, device, dtype: forwarded to :meth:`TorchBicop.from_data`.
     """
+    from ._controls import FitControlsTorchBicop
+
     u_t = torch.as_tensor(u, dtype=dtype, device=device)
     if u_t.ndim != 2:
       raise ValueError(f"u must be 2-D; got shape {tuple(u_t.shape)}")
@@ -295,6 +298,10 @@ class TorchVinecop(torch.nn.Module):
       raise ValueError(
         f"structure.dim={structure.dim} does not match u.shape[1]={d}"
       )
+
+    bc_controls = FitControlsTorchBicop(
+      method="tll", grid_size=grid_size, mult=mult, grid_type=grid_type
+    )
 
     order = [int(s) for s in structure.order]
     hfunc1 = torch.zeros(n, d, dtype=dtype, device=u_t.device)
@@ -315,10 +322,8 @@ class TorchVinecop(torch.nn.Module):
         u_e = torch.stack([col0, col1], dim=-1)
         bc = TorchBicop.from_data(
           u_e,
-          grid_size=grid_size,
-          mult=mult,
+          bc_controls,
           cache_integrals=cache_integrals,
-          grid_type=grid_type,
           device=u_t.device,
           dtype=dtype,
         )

--- a/tests/test_torch_bicop.py
+++ b/tests/test_torch_bicop.py
@@ -14,7 +14,7 @@ import pyvinecopulib as pv
 
 torch = pytest.importorskip("torch")
 
-from pyvinecopulib.torch import TorchBicop  # noqa: E402
+from pyvinecopulib.torch import FitControlsTorchBicop, TorchBicop  # noqa: E402
 
 _TLL_CONTROLS = pv.FitControlsBicop(family_set=[pv.families.tll], num_threads=1)
 
@@ -256,8 +256,12 @@ def test_linear_grid_roundtrip_and_range() -> None:
   """
   cop = pv.Bicop(family=pv.families.gaussian, parameters=np.array([[0.5]]))
   u_fit = cop.simulate(2000, seeds=[10, 11, 12])
-  bc_lin = TorchBicop.from_data(u_fit, grid_type="linear")
-  bc_nrm = TorchBicop.from_data(u_fit, grid_type="normal")
+  bc_lin = TorchBicop.from_data(
+    u_fit, FitControlsTorchBicop(grid_type="linear")
+  )
+  bc_nrm = TorchBicop.from_data(
+    u_fit, FitControlsTorchBicop(grid_type="normal")
+  )
 
   assert bc_lin.interp_grid._is_linear is True
   assert bc_nrm.interp_grid._is_linear is False
@@ -288,7 +292,9 @@ def test_linear_grid_cell_index_matches_searchsorted() -> None:
   """
   cop = pv.Bicop(family=pv.families.gaussian, parameters=np.array([[0.4]]))
   u_fit = cop.simulate(500, seeds=[1, 2, 3])
-  bc_lin = TorchBicop.from_data(u_fit, grid_type="linear")
+  bc_lin = TorchBicop.from_data(
+    u_fit, FitControlsTorchBicop(grid_type="linear")
+  )
   grid = bc_lin.interp_grid
 
   u = torch.linspace(0.0, 1.0, 1001, dtype=torch.float64)
@@ -306,7 +312,9 @@ def test_linear_grid_cached_integrals_consistent() -> None:
   range outputs on the linear grid as well as on the normal grid."""
   cop = pv.Bicop(family=pv.families.gaussian, parameters=np.array([[0.6]]))
   u_fit = cop.simulate(1500, seeds=[7, 8, 9])
-  bc = TorchBicop.from_data(u_fit, grid_type="linear", cache_integrals=True)
+  bc = TorchBicop.from_data(
+    u_fit, FitControlsTorchBicop(grid_type="linear"), cache_integrals=True
+  )
   assert bc._cdf_cache is not None
   assert bc._hfunc1_cache is not None
   assert bc._hfunc2_cache is not None
@@ -324,7 +332,7 @@ def test_linear_rejects_invalid_grid_type() -> None:
   cop = pv.Bicop(family=pv.families.gaussian, parameters=np.array([[0.4]]))
   u_fit = cop.simulate(200, seeds=[1, 2, 3])
   with pytest.raises(ValueError, match="grid_type"):
-    TorchBicop.from_data(u_fit, grid_type="quadratic")
+    TorchBicop.from_data(u_fit, FitControlsTorchBicop(grid_type="quadratic"))
 
 
 # --------------------------------------------------------------------------- #
@@ -360,9 +368,15 @@ def test_from_data_rejects_bad_args() -> None:
   cop = pv.Bicop(family=pv.families.gaussian, parameters=np.array([[0.5]]))
   u_fit = cop.simulate(200, seeds=[1, 2, 3])
   with pytest.raises(ValueError, match="grid_size"):
-    TorchBicop.from_data(u_fit, grid_size=1)
+    TorchBicop.from_data(u_fit, FitControlsTorchBicop(grid_size=1))
   with pytest.raises(ValueError, match="mult"):
-    TorchBicop.from_data(u_fit, mult=0.0)
+    TorchBicop.from_data(u_fit, FitControlsTorchBicop(mult=0.0))
+
+
+def test_from_data_rejects_unknown_method() -> None:
+  """`FitControlsTorchBicop` rejects unknown ``method`` values up-front."""
+  with pytest.raises(ValueError, match="unknown method"):
+    FitControlsTorchBicop(method="bogus")
 
 
 def test_simulate_rejects_nonpositive_n() -> None:
@@ -396,3 +410,46 @@ def test_simulate_alias_of_sample() -> None:
   via_sample_q = bc.sample(num_sample=64, seed=11, is_sobol=True)
   via_simulate_q = bc.simulate(n=64, qrng=True, seeds=[11])
   assert torch.allclose(via_sample_q, via_simulate_q)
+
+
+# ---------------------------------------------------------------------------
+# InterpolationGrid2D.normalize_margins(tol=...) early-stop
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_margins_tol_converges() -> None:
+  """``tol`` early-stops once margins are uniform to the requested
+  precision. The default ``tol=None`` path keeps fixed-budget semantics
+  for C++ TLL parity."""
+  from pyvinecopulib.torch import InterpolationGrid2D
+
+  # Deliberately skewed initial density on a 16x16 linear grid.
+  m = 16
+  grid = torch.linspace(0.0, 1.0, m, dtype=torch.float64)
+  rng = np.random.default_rng(0)
+  values = torch.from_numpy(rng.uniform(0.5, 1.5, size=(m, m)))
+
+  # times=50 with tol=1e-12 should converge to marginals within tol.
+  ig = InterpolationGrid2D(grid, values, norm_times=50, norm_tol=1e-12)
+  dgrid = ig.grid_points[1:] - ig.grid_points[:-1]
+  row_int = 0.5 * ((ig.values[:, :-1] + ig.values[:, 1:]) * dgrid).sum(-1)
+  col_int = 0.5 * (
+    (ig.values[:-1, :] + ig.values[1:, :]) * dgrid.unsqueeze(-1)
+  ).sum(0)
+  assert (row_int - 1.0).abs().max().item() < 1e-10
+  assert (col_int - 1.0).abs().max().item() < 1e-10
+
+
+def test_normalize_margins_default_tol_is_fixed_budget() -> None:
+  """``tol=None`` (default) preserves the fixed-budget loop — same number
+  of divides every time, matching the C++ TLL pipeline's
+  ``normalize_margins(3)`` byte-for-byte. We verify this indirectly by
+  checking that the standard ``from_data`` path still matches C++ to
+  machine precision (covered by ``test_from_data_matches_cpp``); here we
+  just spot-check that the constructor accepts the default."""
+  from pyvinecopulib.torch import InterpolationGrid2D
+
+  grid = torch.linspace(0.0, 1.0, 8, dtype=torch.float64)
+  values = torch.ones(8, 8, dtype=torch.float64)
+  # Should not raise; tol is optional.
+  InterpolationGrid2D(grid, values, norm_times=3)

--- a/tests/test_torch_bicop_vdc.py
+++ b/tests/test_torch_bicop_vdc.py
@@ -1,0 +1,206 @@
+"""Tests for the optional ``method="vdc"`` path in ``TorchBicop.from_data``.
+
+Skipped when either PyTorch or vine-denoising-copula isn't installed.
+Validates that:
+
+* the controls dataclass rejects unknown methods,
+* the resulting grid has the expected shape and boundary endpoints,
+* trapezoidal marginal integrals are already ~1 without
+  ``normalize_margins`` (the algebraic identity that motivates
+  ``norm_times=0`` in the vdc branch of :meth:`TorchBicop.from_data`),
+* ``pdf`` / ``hfunc`` / ``hinv`` round-trip and stay in range,
+* the module-level bundle cache amortizes the HuggingFace download.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import pyvinecopulib as pv
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("vdc")
+
+from pyvinecopulib.torch import FitControlsTorchBicop, TorchBicop  # noqa: E402
+from pyvinecopulib.torch import _fit_vdc as _fit_vdc_mod  # noqa: E402
+
+
+def _vdc_smoke_test_works() -> bool:
+  """Detect upstream-broken vdc wheels.
+
+  As of vdc 0.1.0 on GitHub ``main``, ``load_pretrained_model`` raises
+  ``ModuleNotFoundError`` for ``vdc.inference`` / ``vdc.vine`` —
+  references to submodules that aren't shipped. The integration ships a
+  ``sys.modules`` shim that papers over those gaps for the denoiser
+  inference path (see :func:`_fit_vdc._install_upstream_shims`); we
+  install it here too so the smoke check goes through the same code
+  path as :meth:`TorchBicop.from_data(..., method='vdc')`.
+  """
+  import numpy as np
+
+  import vdc as _vdc
+
+  _fit_vdc_mod._install_upstream_shims()
+  try:
+    bundle = _vdc.load_pretrained_model("vdc-denoiser-m64-v1", device="cpu")
+    _vdc.estimate_pair_density_from_samples(
+      bundle, np.random.uniform(size=(50, 2))
+    )
+    return True
+  except ModuleNotFoundError:
+    return False
+
+
+if not _vdc_smoke_test_works():
+  pytest.skip(
+    "vdc package is installed but unusable (upstream wheel references "
+    "missing submodules `vdc.inference` and `vdc.vine`). Re-enable these "
+    "tests once vdc restores the missing subpackages.",
+    allow_module_level=True,
+  )
+
+
+def _gaussian_sample(rho: float, n: int = 2000, seed: int = 1) -> np.ndarray:
+  cop = pv.Bicop(family=pv.families.gaussian, parameters=np.array([[rho]]))
+  return cop.simulate(n, seeds=[seed, seed + 1, seed + 2])
+
+
+def _eval_grid(n: int, seed: int = 0) -> np.ndarray:
+  rng = np.random.default_rng(seed)
+  return rng.uniform(0.02, 0.98, size=(n, 2))
+
+
+@pytest.fixture
+def vdc_bicop():
+  """Single shared fit reused across tests to keep CI cheap."""
+  u_fit = _gaussian_sample(rho=0.6, n=2000, seed=1)
+  return TorchBicop.from_data(
+    torch.from_numpy(u_fit), FitControlsTorchBicop(method="vdc")
+  )
+
+
+def test_grid_shape_and_endpoints(vdc_bicop: TorchBicop) -> None:
+  """The padded grid is (m+2, m+2) on [0, cc..., 1]; pretrained ``m=64``
+  gives ``(66, 66)`` values."""
+  g = vdc_bicop.interp_grid
+  assert g.values.shape == (66, 66)
+  assert g.grid_points.shape == (66,)
+  assert g.grid_points[0].item() == pytest.approx(0.0, abs=0.0)
+  assert g.grid_points[-1].item() == pytest.approx(1.0, abs=0.0)
+  # Interior is cell-centers: (0.5/m, 1.5/m, ..., (m-0.5)/m).
+  interior = g.grid_points[1:-1].numpy()
+  expected = (np.arange(64) + 0.5) / 64.0
+  np.testing.assert_allclose(interior, expected, atol=1e-12)
+
+
+def test_marginals_are_uniform_without_normalization(
+  vdc_bicop: TorchBicop,
+) -> None:
+  """vdc's IPFP enforces midpoint-rule uniform marginals on the
+  cell-center grid; with replicate-padding the trapezoidal integral on
+  the (m+2)-grid coincides with that midpoint sum at every cell center.
+  So row/column trapezoidal sums must equal 1 without us running a
+  single ``normalize_margins`` round (``norm_times=0`` in the vdc
+  branch)."""
+  g = vdc_bicop.interp_grid
+  dgrid = g.grid_points[1:] - g.grid_points[:-1]
+  row_int = 0.5 * ((g.values[:, :-1] + g.values[:, 1:]) * dgrid).sum(-1)
+  col_int = 0.5 * (
+    (g.values[:-1, :] + g.values[1:, :]) * dgrid.unsqueeze(-1)
+  ).sum(0)
+  # vdc's projection_iters=50 gets to ~1e-6 marginals; the algebraic
+  # identity then preserves that on the padded grid.
+  assert (row_int - 1.0).abs().max().item() < 5e-5
+  assert (col_int - 1.0).abs().max().item() < 5e-5
+
+
+def test_pdf_hfunc_hinv_in_range(vdc_bicop: TorchBicop) -> None:
+  u_t = torch.from_numpy(_eval_grid(400, seed=7))
+  pdf = vdc_bicop.pdf(u_t)
+  h1 = vdc_bicop.hfunc1(u_t)
+  h2 = vdc_bicop.hfunc2(u_t)
+  assert (pdf > 0).all() and torch.isfinite(pdf).all()
+  assert ((h1 >= 0) & (h1 <= 1)).all()
+  assert ((h2 >= 0) & (h2 <= 1)).all()
+
+
+def test_hinv_roundtrip(vdc_bicop: TorchBicop) -> None:
+  """``hinv1(hfunc1(u)) ≈ u`` on the second argument. ITP bisection is
+  fixed-iter so we expect ~1e-3 at m=64."""
+  u_t = torch.from_numpy(_eval_grid(400, seed=11))
+  u2 = vdc_bicop.hinv1(u_t).unsqueeze(-1)
+  back = vdc_bicop.hfunc1(torch.cat([u_t[:, 0:1], u2], dim=-1)).numpy()
+  np.testing.assert_allclose(back, u_t[:, 1].numpy(), atol=2e-3, rtol=0.0)
+
+
+def test_independence_smoke() -> None:
+  """On iid uniform samples, vdc should at least integrate to 1 and stay
+  finite. The denoiser's accuracy on the independence copula is
+  disappointing (mean |pdf - 1| ≈ 0.9 in practice — see the precision
+  bench for numbers), but that's an upstream model-quality issue, not
+  an integration bug. This test just verifies the wrapper works."""
+  rng = np.random.default_rng(42)
+  u_fit = rng.uniform(size=(4000, 2))
+  bc = TorchBicop.from_data(
+    torch.from_numpy(u_fit), FitControlsTorchBicop(method="vdc")
+  )
+  u_eval = torch.from_numpy(_eval_grid(2000, seed=99))
+  pdf = bc.pdf(u_eval).numpy()
+  assert np.isfinite(pdf).all()
+  assert (pdf >= 0).all()
+  # Marginals were already validated in test_marginals_are_uniform_*.
+
+
+def test_tll_and_vdc_both_recover_gaussian() -> None:
+  """Both backends fit and produce distinct grids (so the dispatch is
+  exercised, not a silent fall-through). Accuracy thresholds are loose
+  for vdc — the released denoiser checkpoint underperforms TLL on
+  Gaussian by a wide margin in practice; the precision bench reports
+  the actual numbers."""
+  u_fit = _gaussian_sample(rho=0.6, n=4000, seed=21)
+  u_fit_t = torch.from_numpy(u_fit)
+  bc_tll = TorchBicop.from_data(u_fit_t, FitControlsTorchBicop(method="tll"))
+  bc_vdc = TorchBicop.from_data(u_fit_t, FitControlsTorchBicop(method="vdc"))
+
+  # Different grid sizes — definitely not the same object/values.
+  assert bc_tll.interp_grid.values.shape != bc_vdc.interp_grid.values.shape
+
+  truth = pv.Bicop(family=pv.families.gaussian, parameters=np.array([[0.6]]))
+  u_eval = _eval_grid(2000, seed=33)
+  u_eval_t = torch.from_numpy(u_eval)
+  truth_h = truth.hfunc1(u_eval)
+  tll_iae = float(np.mean(np.abs(bc_tll.hfunc1(u_eval_t).numpy() - truth_h)))
+  vdc_iae = float(np.mean(np.abs(bc_vdc.hfunc1(u_eval_t).numpy() - truth_h)))
+  assert tll_iae < 0.03
+  # vdc denoiser checkpoint accuracy on Gaussian copula is poor — observed
+  # hfunc1 IAE ≈ 0.19. Threshold leaves headroom; the bench surfaces the
+  # real number for follow-up.
+  assert vdc_iae < 0.30
+
+
+def test_bundle_cache_amortizes_load(monkeypatch) -> None:
+  """Successive vdc fits should reuse the cached
+  ``LoadedPretrainedModel`` — the HuggingFace download happens once per
+  process."""
+  # Reset cache so we start clean.
+  _fit_vdc_mod._BUNDLE_CACHE.clear()
+  import vdc as _vdc_pkg
+
+  call_count = {"n": 0}
+  real_loader = _vdc_pkg.load_pretrained_model
+
+  def _counting_loader(model_id, *args, **kwargs):
+    call_count["n"] += 1
+    return real_loader(model_id, *args, **kwargs)
+
+  monkeypatch.setattr(_vdc_pkg, "load_pretrained_model", _counting_loader)
+
+  u_fit = _gaussian_sample(rho=0.4, n=500, seed=51)
+  TorchBicop.from_data(
+    torch.from_numpy(u_fit), FitControlsTorchBicop(method="vdc")
+  )
+  TorchBicop.from_data(
+    torch.from_numpy(u_fit), FitControlsTorchBicop(method="vdc")
+  )
+  assert call_count["n"] == 1


### PR DESCRIPTION
## Summary

Adds a pluggable bicop-fitter API to the torch backend, and integrates the
[vine-denoising-copula](https://github.com/KempnerInstitute/vine-denoising-copula)
([arXiv:2604.20568](https://arxiv.org/abs/2604.20568)) as the first
non-TLL fitter behind it.

- **`FitControlsTorchBicop` dataclass** mirrors `pv.FitControlsBicop`.
  `TorchBicop.from_data(u, controls=None, *, cache_integrals=False, device=None, dtype=...)`
  now dispatches on `controls.method` (`"tll"` default, `"vdc"` new).
  Method-specific args live on controls; cross-cutting args stay on
  `from_data` — adding a third fitter only extends the dataclass.
- **`method="vdc"`** wraps `vdc.estimate_pair_density_from_samples`,
  replicate-pads the resulting `(m, m)` cell-centered density to
  `(m+2, m+2)` on `[0, 0.5/m, …, (m-0.5)/m, 1]`, and feeds it into the
  existing `InterpolationGrid2D` with `norm_times=0`. The padding gives
  trapezoidal integration on our grid that's algebraically equivalent to
  vdc's midpoint-cumsum at every cell center — so marginals stay uniform
  (vdc's IPFP already converged) and h-functions match vdc's formula
  exactly, with no eval-time boundary patching.
- **`InterpolationGrid2D.normalize_margins`** gained an optional `tol`
  early-stop. Default `tol=None` preserves byte-for-byte C++ TLL parity;
  passing e.g. `tol=1e-9` lets advanced callers iterate to convergence
  (matching vdc's 50-iter IPFP).
- **Bench scripts extended**: `--grid-sizes` axis on both
  `bench_torch_bicop_fit.py` and `bench_torch_precision.py` for
  apples-to-apples comparison against vdc's fixed `m=64`. Also
  `--methods` and `vdc` backend support.

## Apples-to-apples results

Run on an RTX 2080 Ti, `m=64`, normal storage grid, single-thread C++.

**Fit speed** (median of 5 repeats):

| n | cpp CPU TLL | torch CUDA TLL | torch CUDA VDC |
|---:|---:|---:|---:|
| 500 | 20 ms | 13 ms | 16 ms |
| 2000 | 73 ms | 21 ms | 17 ms |
| 10000 | 348 ms | 63 ms | **20 ms** |

vdc fit time is essentially constant in `n` — one UNet forward pass +
50-iter IPFP on a 64×64 grid. At n=10000 vdc is **17× faster** than C++ CPU TLL.

**Precision** (pdf IAE on 10k iid eval points, no cache):

| family | params | n | TLL | **VDC** |
|---|---:|---:|---:|---:|
| Gaussian | ρ=0.3 | 10000 | 3.3e-2 | 7.7e-1 |
| Gaussian | ρ=0.7 | 10000 | 3.4e-2 | 7.5e-1 |
| Clayton | θ=2 | 10000 | 5.1e-2 | 7.6e-1 |
| Clayton | θ=5 | 10000 | 7.7e-2 | 9.2e-1 |

vdc is 10–25× **worse** than TLL on the standard parametric families.
A direct probe of `vdc.estimate_pair_density_from_samples` on iid
uniform input (independence copula → c = 1 everywhere) produces densities
up to 57× too large near the anti-diagonal corners. This is the released
`vdc-denoiser-m64-v1` checkpoint behaving poorly on simple shapes — not
the integration. Re-run when upstream ships a better checkpoint.

## Distribution

vdc is not on PyPI yet. The new `[vdc]` optional-dependency extra +
`[tool.uv.sources]` block in `pyproject.toml` resolves it from GitHub
for `uv` users; plain pip users install
`vine-denoising-copula @ git+https://github.com/KempnerInstitute/vine-denoising-copula`
directly. Error message in `_try_import_vdc` points at both paths.

## Upstream-bug shim

vdc 0.1.0 on `main` ships an incomplete wheel — `vdc.load_pretrained_model`
references `vdc.inference.density` and `vdc.vine.copula_diffusion` which
aren't packaged. `_fit_vdc._install_upstream_shims()` injects `sys.modules`
stubs for both (the real `scatter_to_hist` is loaded directly from
`vdc/data/hist.py` via `importlib.util`; the two truly-missing entry
points only matter for the diffusion / training paths we don't hit and
get `NotImplementedError` / placeholder-class stubs). The shim self-disables
once upstream restores the missing subpackages.

## Test plan

- [x] `uv run pytest tests/test_torch_bicop.py` — 36 passed (existing TLL
      parity + new normalize_margins tol regression)
- [x] `uv run pytest tests/test_torch_bicop_vdc.py` — 7 passed (grid shape,
      marginal-integral identity, pdf/hfunc/hinv ranges, hinv round-trip,
      bundle cache, indep & Gaussian smoke with loose thresholds)
- [x] `uv run pytest tests/test_torch_vinecop.py tests/test_torch_batched.py`
      — 55 passed (no regressions from the `from_data` signature change)
- [x] `uv run ruff check src tests scripts && uv run ruff format --check src tests`
- [x] `uv run python scripts/bench_torch_bicop_fit.py --mode fit --backends cpp,torch,vdc --devices cuda --grid-sizes 64 ...`
      produces the table above
- [x] `uv run python scripts/bench_torch_precision.py --methods tll,vdc --grid-sizes 64 ...`
      produces the precision table above

## Breaking change

`TorchBicop.from_data` signature changed from `(u, grid_size=30, mult=1.0,
cache_integrals=False, grid_type='normal', device=None, dtype=...)` to
`(u, controls=None, *, cache_integrals=False, device=None, dtype=...)`.
Callers passing `grid_size` / `mult` / `grid_type` as kwargs must wrap them
in `FitControlsTorchBicop(...)`. Acceptable on `feature/vdc` (pre-1.0 branch)
— all in-repo callers (vinecop.py, bench scripts, notebook, tests) are
updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
