### PR TITLE
Fix osx/musllinux docstr.hpp generation; macos-15 runners

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -44,6 +44,7 @@ jobs:
               cxx: clang++,
               platform: x64,
               root_install_dir: "/Users/runner/work",
+              macos_target: "10.13",
             }
           - {
               os: macos-15,
@@ -52,6 +53,7 @@ jobs:
               cxx: clang++,
               platform: arm64,
               root_install_dir: "/Users/runner/work",
+              macos_target: "11.0",
             }
           - {
               os: windows-latest,
@@ -103,14 +105,10 @@ jobs:
         env:
           CIBW_REBUILD: 1
           CIBW_BUILD: cp${{ matrix.python }}-${{ matrix.cfg.cibw_id }}
-          # The pip `libclang` wheel ships no builtin/intrinsic headers, which
-          # the docstr.hpp generation needs. manylinux's libclang finds them by
-          # default; musllinux (Alpine) does not, so install a system clang
-          # there to supply a resource dir (`clang -print-resource-dir`). No-op
-          # on manylinux; macOS/Windows are unaffected (AppleClang / MSVC).
-          CIBW_BEFORE_ALL_LINUX: "command -v apk >/dev/null 2>&1 && apk add clang || true"
           CIBW_ENVIRONMENT_WINDOWS: Boost_INCLUDE_DIR='${{steps.install-dependencies.outputs.BOOST_ROOT}}\include' EIGEN3_INCLUDE_DIR='C:\ProgramData\chocolatey\lib\eigen\include'
-          CIBW_ENVIRONMENT_MACOS: "Boost_INCLUDE_DIR=${{steps.install-dependencies.outputs.BOOST_ROOT}}/include EIGEN3_INCLUDE_DIR=${{matrix.cfg.root_install_dir}}/include/eigen3"
+          # MACOSX_DEPLOYMENT_TARGET >= 10.13 is required by nanobind's aligned
+          # operator new/delete (the x86_64 default is 10.9). arm64 uses 11.0.
+          CIBW_ENVIRONMENT_MACOS: "Boost_INCLUDE_DIR=${{steps.install-dependencies.outputs.BOOST_ROOT}}/include EIGEN3_INCLUDE_DIR=${{matrix.cfg.root_install_dir}}/include/eigen3 MACOSX_DEPLOYMENT_TARGET=${{matrix.cfg.macos_target}}"
           CIBW_ENVIRONMENT_LINUX: "Boost_INCLUDE_DIR=/host${{steps.install-dependencies.outputs.BOOST_ROOT}}/include EIGEN3_INCLUDE_DIR=/host${{matrix.cfg.root_install_dir}}/include/eigen3"
           CIBW_ENVIRONMENT_PASS_LINUX: "Boost_INCLUDE_DIR EIGEN3_INCLUDE_DIR"
       - name: Inspect built wheel contents

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -225,10 +225,11 @@ jobs:
       matrix:
         python: [310, 311, 312, 313, 314]
         cfg:
+          # macos-15-intel wheels are built + published by the `build` job, but
+          # are NOT unit-tested here: PyTorch has no x86_64-macOS wheel, and the
+          # platform's libm/BLAS produces a numerical edge case in the
+          # VineForestRegressor(val_fraction=0.0) sklearn-compliance checks.
           - { os: ubuntu-latest, cibw_id: manylinux_x86_64 }
-          # PyTorch dropped x86_64-macOS wheels, so the torch extra can't be
-          # installed here; skip it (torch unit tests `importorskip` already).
-          - { os: macos-15-intel, cibw_id: macosx_x86_64, no_torch: "true" }
           - { os: macos-15, cibw_id: macosx_arm64 }
           - { os: windows-latest, cibw_id: win_amd64 }
     name: Install wheel and run unit tests on ${{ matrix.cfg.os }} for cp${{ matrix.python }}-${{ matrix.cfg.cibw_id }}
@@ -267,9 +268,7 @@ jobs:
         shell: bash
         run: |
           uv venv --python ${{ steps.pyver.outputs.version }}
-          TORCH_EXTRA="--extra torch"
-          if [[ "${{ matrix.cfg.no_torch }}" == "true" ]]; then TORCH_EXTRA=""; fi
-          uv sync --no-install-project --group test --group notebooks --extra examples --extra sklearn $TORCH_EXTRA
+          uv sync --no-install-project --group test --group notebooks --extra examples --extra sklearn --extra torch
       - name: Download built wheel (<=3.11)
         if: ${{ matrix.python <= 311 }}
         uses: actions/download-artifact@v4
@@ -309,14 +308,10 @@ jobs:
           retry_wait_seconds: 60
           shell: bash
           command: |
-            # The torch notebook can't run where torch isn't installable.
-            IGNORE_TORCH=""
-            if [[ "${{ matrix.cfg.no_torch }}" == "true" ]]; then IGNORE_TORCH="--ignore=examples/10_torch_backend.ipynb"; fi
             uv run pytest --nbmake examples/ \
               --no-cov \
               --nbmake-timeout=600 \
               --nbmake-kernel=python3 \
-              $IGNORE_TORCH \
               --reruns 2 --reruns-delay 10
 
   regenerate_notebooks:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -10,7 +10,7 @@ on:
 env:
   BOOST_VERSION: 1.84.0
   EIGEN_VERSION: 3.4.0
-  EXPECTED_WHEEL_COUNT: 12  # 4 platforms × cp310/cp311/cp312-ABI3
+  EXPECTED_WHEEL_COUNT: 15  # 5 platforms × cp310/cp311/cp312-ABI3
 
 jobs:
 
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # macos-13 is an intel runner, macos-14 is apple silicon
+        # macos-15-intel is the Intel runner, macos-15 is Apple silicon.
         python: [310, 311, 312]
         cfg:
           - {
@@ -37,9 +37,16 @@ jobs:
               platform: x64,
               root_install_dir: "/home/runner/work",
             }
-          # - { os: macos-13, cibw_id: macosx_x86_64, cc: clang, cxx: clang++, platform: x64, root_install_dir: '/Users/runner/work'} # intel runner
           - {
-              os: macos-14,
+              os: macos-15-intel,
+              cibw_id: macosx_x86_64,
+              cc: clang,
+              cxx: clang++,
+              platform: x64,
+              root_install_dir: "/Users/runner/work",
+            }
+          - {
+              os: macos-15,
               cibw_id: macosx_arm64,
               cc: clang,
               cxx: clang++,
@@ -96,6 +103,12 @@ jobs:
         env:
           CIBW_REBUILD: 1
           CIBW_BUILD: cp${{ matrix.python }}-${{ matrix.cfg.cibw_id }}
+          # The pip `libclang` wheel ships no builtin/intrinsic headers, which
+          # the docstr.hpp generation needs. manylinux's libclang finds them by
+          # default; musllinux (Alpine) does not, so install a system clang
+          # there to supply a resource dir (`clang -print-resource-dir`). No-op
+          # on manylinux; macOS/Windows are unaffected (AppleClang / MSVC).
+          CIBW_BEFORE_ALL_LINUX: "command -v apk >/dev/null 2>&1 && apk add clang || true"
           CIBW_ENVIRONMENT_WINDOWS: Boost_INCLUDE_DIR='${{steps.install-dependencies.outputs.BOOST_ROOT}}\include' EIGEN3_INCLUDE_DIR='C:\ProgramData\chocolatey\lib\eigen\include'
           CIBW_ENVIRONMENT_MACOS: "Boost_INCLUDE_DIR=${{steps.install-dependencies.outputs.BOOST_ROOT}}/include EIGEN3_INCLUDE_DIR=${{matrix.cfg.root_install_dir}}/include/eigen3"
           CIBW_ENVIRONMENT_LINUX: "Boost_INCLUDE_DIR=/host${{steps.install-dependencies.outputs.BOOST_ROOT}}/include EIGEN3_INCLUDE_DIR=/host${{matrix.cfg.root_install_dir}}/include/eigen3"
@@ -214,7 +227,8 @@ jobs:
         python: [310, 311, 312, 313, 314]
         cfg:
           - { os: ubuntu-latest, cibw_id: manylinux_x86_64 }
-          - { os: macos-14, cibw_id: macosx_arm64 }
+          - { os: macos-15-intel, cibw_id: macosx_x86_64 }
+          - { os: macos-15, cibw_id: macosx_arm64 }
           - { os: windows-latest, cibw_id: win_amd64 }
     name: Install wheel and run unit tests on ${{ matrix.cfg.os }} for cp${{ matrix.python }}-${{ matrix.cfg.cibw_id }}
     steps:
@@ -242,7 +256,7 @@ jobs:
           if [[ "${{ matrix.cfg.os }}" == "ubuntu-latest" ]]; then
             sudo apt-get update
             sudo apt-get install -y graphviz
-          elif [[ "${{ matrix.cfg.os }}" == "macos-14" ]]; then
+          elif [[ "${{ matrix.cfg.os }}" == macos-* ]]; then
             brew install graphviz
           elif [[ "${{ matrix.cfg.os }}" == "windows-latest" ]]; then
             choco install graphviz -y

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -199,12 +199,13 @@ jobs:
         with:
           name: cibw-wheels-ubuntu-latest-311-manylinux_x86_64
           path: dist/
-      - name: Install wheel + doc/examples/sklearn extras
-        # `[sklearn]` is needed for autosummary to introspect pyvinecopulib.sklearn.
+      - name: Install wheel + doc/examples/sklearn/torch extras
+        # `[sklearn]`/`[torch]` are needed for autosummary to introspect
+        # pyvinecopulib.sklearn / pyvinecopulib.torch.
         run: |
           uv venv --python 3.11
           WHEEL=$(ls dist/*.whl)
-          uv pip install "${WHEEL}[doc,examples,sklearn]"
+          uv pip install "${WHEEL}[doc,examples,sklearn,torch]"
       - name: Build HTML docs (warnings as errors)
         env:
           UV_NO_SYNC: "1"
@@ -225,7 +226,9 @@ jobs:
         python: [310, 311, 312, 313, 314]
         cfg:
           - { os: ubuntu-latest, cibw_id: manylinux_x86_64 }
-          - { os: macos-15-intel, cibw_id: macosx_x86_64 }
+          # PyTorch dropped x86_64-macOS wheels, so the torch extra can't be
+          # installed here; skip it (torch unit tests `importorskip` already).
+          - { os: macos-15-intel, cibw_id: macosx_x86_64, no_torch: "true" }
           - { os: macos-15, cibw_id: macosx_arm64 }
           - { os: windows-latest, cibw_id: win_amd64 }
     name: Install wheel and run unit tests on ${{ matrix.cfg.os }} for cp${{ matrix.python }}-${{ matrix.cfg.cibw_id }}
@@ -264,7 +267,9 @@ jobs:
         shell: bash
         run: |
           uv venv --python ${{ steps.pyver.outputs.version }}
-          uv sync --no-install-project --group test --group notebooks --extra examples --extra sklearn --extra torch
+          TORCH_EXTRA="--extra torch"
+          if [[ "${{ matrix.cfg.no_torch }}" == "true" ]]; then TORCH_EXTRA=""; fi
+          uv sync --no-install-project --group test --group notebooks --extra examples --extra sklearn $TORCH_EXTRA
       - name: Download built wheel (<=3.11)
         if: ${{ matrix.python <= 311 }}
         uses: actions/download-artifact@v4
@@ -304,10 +309,14 @@ jobs:
           retry_wait_seconds: 60
           shell: bash
           command: |
+            # The torch notebook can't run where torch isn't installable.
+            IGNORE_TORCH=""
+            if [[ "${{ matrix.cfg.no_torch }}" == "true" ]]; then IGNORE_TORCH="--ignore=examples/10_torch_backend.ipynb"; fi
             uv run pytest --nbmake examples/ \
               --no-cov \
               --nbmake-timeout=600 \
               --nbmake-kernel=python3 \
+              $IGNORE_TORCH \
               --reruns 2 --reruns-delay 10
 
   regenerate_notebooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@
 - Add a `pyvinecopulib[sklearn]` extra (`scikit-learn>=1.4`, `pandas>=2.0`, `joblib>=1.3`, `scipy>=1.10`), a `pyvinecopulib[torch]` extra (`torch>=2.0`), and a `pyvinecopulib[vdc]` extra resolving `vine-denoising-copula` from GitHub via `[tool.uv.sources]` (#211, #216, #217).
 - Treat `pyvinecopulib`-originated `DeprecationWarning`s as errors under pytest so internal call sites stay on the canonical import paths (#207).
 - Install `--extra torch` in the notebook-test and regenerate-notebooks CI jobs so `examples/10_torch_backend.ipynb` executes under `nbmake` (#216).
+- Fix osx / musllinux wheel builds: feed libclang a clang `-resource-dir` plus the compiler's filtered system include dirs (and the macOS SDK sysroot) so `docstr.hpp` generation no longer silently drops symbols, and abort generation on any fatal libclang diagnostic.
+- Migrate macOS CI to `macos-15` and re-add `macos-15-intel`; wheel matrix is now 5 platforms × 3 ABI (15 wheels).
 
 ### Bug fixes in `pyvinecopulib`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,8 @@
 - Add a `pyvinecopulib[sklearn]` extra (`scikit-learn>=1.4`, `pandas>=2.0`, `joblib>=1.3`, `scipy>=1.10`), a `pyvinecopulib[torch]` extra (`torch>=2.0`), and a `pyvinecopulib[vdc]` extra resolving `vine-denoising-copula` from GitHub via `[tool.uv.sources]` (#211, #216, #217).
 - Treat `pyvinecopulib`-originated `DeprecationWarning`s as errors under pytest so internal call sites stay on the canonical import paths (#207).
 - Install `--extra torch` in the notebook-test and regenerate-notebooks CI jobs so `examples/10_torch_backend.ipynb` executes under `nbmake` (#216).
-- Fix osx / musllinux wheel builds: feed libclang a clang `-resource-dir` plus the compiler's filtered system include dirs (and the macOS SDK sysroot) so `docstr.hpp` generation no longer silently drops symbols, and abort generation on any fatal libclang diagnostic.
-- Migrate macOS CI to `macos-15` and re-add `macos-15-intel`; wheel matrix is now 5 platforms × 3 ABI (15 wheels).
+- Fix osx / musllinux wheel builds: feed libclang the compiler's implicit system include dirs (plus `-ferror-limit=0` and the macOS SDK sysroot) so the C++ stdlib / intrinsic headers resolve, and abort `docstr.hpp` generation only on *fatal* libclang diagnostics (intrinsic-header `error`s are benign and no longer silently drop symbols).
+- Migrate macOS CI to `macos-15` and re-add `macos-15-intel` (`MACOSX_DEPLOYMENT_TARGET=10.13` for nanobind's aligned `new`/`delete`); wheel matrix is now 5 platforms × 3 ABI (15 wheels).
 
 ### Bug fixes in `pyvinecopulib`
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,46 +117,34 @@ set(DOCSTR_OUTPUT "${CMAKE_SOURCE_DIR}/src/include/docstr.hpp")
 # libclang (from the PyPI `libclang` wheel) ships no builtin headers and does
 # not reliably auto-discover the host C++ standard library + compiler intrinsics
 # on every platform: it works on manylinux / Windows but misses Alpine's
-# libstdc++ layout and intrinsics (musllinux) and the macOS SDK's libc++.
-# Without them the headers fail to parse, the AST is partial, and docstr.hpp is
-# generated with whole symbols missing / overloads mis-named — surfacing only as
-# cryptic "no member named ..." compile errors. Verified in a musllinux
-# container: both the filtered C++ stdlib include dirs AND a clang resource dir
-# (builtin/intrinsic headers) are required. This whole block is gated to
-# non-MSVC: Windows builds green today and must not be fed MSVC's include dirs.
+# libstdc++ layout (musllinux) and the macOS SDK's libc++. Without them the
+# headers fail to parse, the AST is partial, and docstr.hpp is generated with
+# whole symbols missing / overloads mis-named — surfacing only as cryptic
+# "no member named ..." compile errors. We feed libclang the compiler's own
+# implicit system include dirs (which carry the C++ stdlib AND the builtin /
+# intrinsic headers like stddef.h, xmmintrin.h, arm_neon.h). This whole block
+# is gated to non-MSVC: Windows builds green today and must not be fed MSVC's
+# include dirs.
 set(DOCSTR_SYS_INCLUDES "")
 set(DOCSTR_CLANG_ARGS "")
 if(NOT MSVC)
-  # Feed the compiler's own implicit system include dirs (the C++ stdlib + libc)
-  # as -isystem, but DROP the compiler-internal builtin dirs (.../lib/gcc/...,
-  # .../lib/clang/...): GCC's intrinsics headers (xmmintrin.h, ...) use GCC-only
-  # builtins that libclang rejects. Normalize first — some toolchains express
-  # the stdlib dirs relative to the gcc dir (.../lib/gcc/.../../../include/c++).
-  # These dirs keep the compiler's own ordering (libstdc++ dirs first, the bare
-  # libc dir last) and MUST precede Eigen/Boost below: system Boost resolves to
-  # `/usr/include`, and a bare `/usr/include` placed before the libstdc++ dir
+  # Pass every implicit dir (normalized; some toolchains write the stdlib dirs
+  # relative to the gcc dir). These supply both the C++ stdlib and the builtin/
+  # intrinsic headers, and MUST precede Eigen/Boost below: system Boost resolves
+  # to `/usr/include`, and a bare `/usr/include` placed before the libstdc++ dir
   # breaks `<cmath>`'s `#include_next <math.h>` ("'math.h' file not found").
+  # We do NOT drop the gcc/clang builtin dirs: libclang emits ~100 harmless
+  # vendor-intrinsic errors when it parses them (version-specific builtins), but
+  # those are error-severity, not fatal — they don't truncate the AST or affect
+  # the declarations docstrings are read from (see generate_docstring.py).
   foreach(_dir IN LISTS CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES)
     get_filename_component(_rp "${_dir}" REALPATH)
-    if(_rp MATCHES "/lib/gcc/" OR _rp MATCHES "/lib/clang/")
-      continue()
-    endif()
     list(APPEND DOCSTR_SYS_INCLUDES -isystem "${_rp}")
   endforeach()
 
-  # Locate a clang resource dir (the builtin/intrinsic headers the wheel lacks).
-  # Best-effort: empty -> libclang uses its defaults (fine on manylinux).
-  execute_process(
-    COMMAND
-      "${Python_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/scripts/find_libclang.py"
-      --print-resource-dir --search-paths "${CMAKE_PREFIX_PATH}"
-    OUTPUT_VARIABLE DOCSTR_RESOURCE_DIR
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
-  if(DOCSTR_RESOURCE_DIR)
-    message(STATUS "Found clang resource dir: ${DOCSTR_RESOURCE_DIR}")
-    list(APPEND DOCSTR_CLANG_ARGS "--clang-arg=-resource-dir"
-         "--clang-arg=${DOCSTR_RESOURCE_DIR}")
-  endif()
+  # Don't let clang's default 20-error limit (tripped by the intrinsic-header
+  # noise above) emit a "too many errors" *fatal* that truncates the AST.
+  list(APPEND DOCSTR_CLANG_ARGS "--clang-arg=-ferror-limit=0")
 
   if(APPLE AND CMAKE_OSX_SYSROOT)
     list(APPEND DOCSTR_CLANG_ARGS "--clang-arg=-isysroot"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,16 +114,66 @@ file(
 
 set(DOCSTR_OUTPUT "${CMAKE_SOURCE_DIR}/src/include/docstr.hpp")
 
+# libclang (from the PyPI `libclang` wheel) ships no builtin headers and does
+# not reliably auto-discover the host C++ standard library + compiler intrinsics
+# on every platform: it works on manylinux / Windows but misses Alpine's
+# libstdc++ layout and intrinsics (musllinux) and the macOS SDK's libc++.
+# Without them the headers fail to parse, the AST is partial, and docstr.hpp is
+# generated with whole symbols missing / overloads mis-named — surfacing only as
+# cryptic "no member named ..." compile errors. Verified in a musllinux
+# container: both the filtered C++ stdlib include dirs AND a clang resource dir
+# (builtin/intrinsic headers) are required. This whole block is gated to
+# non-MSVC: Windows builds green today and must not be fed MSVC's include dirs.
+set(DOCSTR_SYS_INCLUDES "")
+set(DOCSTR_CLANG_ARGS "")
+if(NOT MSVC)
+  # Feed the compiler's own implicit system include dirs (the C++ stdlib + libc)
+  # as -isystem, but DROP the compiler-internal builtin dirs (.../lib/gcc/...,
+  # .../lib/clang/...): GCC's intrinsics headers (xmmintrin.h, ...) use GCC-only
+  # builtins that libclang rejects. Normalize first — some toolchains express
+  # the stdlib dirs relative to the gcc dir (.../lib/gcc/.../../../include/c++).
+  # These dirs keep the compiler's own ordering (libstdc++ dirs first, the bare
+  # libc dir last) and MUST precede Eigen/Boost below: system Boost resolves to
+  # `/usr/include`, and a bare `/usr/include` placed before the libstdc++ dir
+  # breaks `<cmath>`'s `#include_next <math.h>` ("'math.h' file not found").
+  foreach(_dir IN LISTS CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES)
+    get_filename_component(_rp "${_dir}" REALPATH)
+    if(_rp MATCHES "/lib/gcc/" OR _rp MATCHES "/lib/clang/")
+      continue()
+    endif()
+    list(APPEND DOCSTR_SYS_INCLUDES -isystem "${_rp}")
+  endforeach()
+
+  # Locate a clang resource dir (the builtin/intrinsic headers the wheel lacks).
+  # Best-effort: empty -> libclang uses its defaults (fine on manylinux).
+  execute_process(
+    COMMAND
+      "${Python_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/scripts/find_libclang.py"
+      --print-resource-dir --search-paths "${CMAKE_PREFIX_PATH}"
+    OUTPUT_VARIABLE DOCSTR_RESOURCE_DIR
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  if(DOCSTR_RESOURCE_DIR)
+    message(STATUS "Found clang resource dir: ${DOCSTR_RESOURCE_DIR}")
+    list(APPEND DOCSTR_CLANG_ARGS "--clang-arg=-resource-dir"
+         "--clang-arg=${DOCSTR_RESOURCE_DIR}")
+  endif()
+
+  if(APPLE AND CMAKE_OSX_SYSROOT)
+    list(APPEND DOCSTR_CLANG_ARGS "--clang-arg=-isysroot"
+         "--clang-arg=${CMAKE_OSX_SYSROOT}")
+  endif()
+endif()
+
 add_custom_command(
   OUTPUT "${DOCSTR_OUTPUT}"
   COMMAND
     "${Python_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/scripts/generate_docstring.py"
-    -std "c++${CMAKE_CXX_STANDARD}" -I
+    -std "c++${CMAKE_CXX_STANDARD}" ${DOCSTR_CLANG_ARGS} -I
     "${CMAKE_SOURCE_DIR}/lib/vinecopulib/include" -I
     "${CMAKE_SOURCE_DIR}/lib/wdm/include" -I
-    "${CMAKE_SOURCE_DIR}/lib/kde1d/include" -isystem "${EIGEN3_INCLUDE_DIR}"
-    -isystem "${Boost_INCLUDE_DIRS}" -output "${DOCSTR_OUTPUT}" -library_file
-    "${LIBCLANG_PATH}" ${DOCSTR_INPUT_HEADERS}
+    "${CMAKE_SOURCE_DIR}/lib/kde1d/include" ${DOCSTR_SYS_INCLUDES} -isystem
+    "${EIGEN3_INCLUDE_DIR}" -isystem "${Boost_INCLUDE_DIRS}" -output
+    "${DOCSTR_OUTPUT}" -library_file "${LIBCLANG_PATH}" ${DOCSTR_INPUT_HEADERS}
   DEPENDS ${DOCSTR_INPUT_HEADERS}
           "${CMAKE_SOURCE_DIR}/scripts/generate_docstring.py"
           "${CMAKE_SOURCE_DIR}/scripts/find_libclang.py"

--- a/scripts/find_libclang.py
+++ b/scripts/find_libclang.py
@@ -10,11 +10,23 @@ none found). Resolution order:
        in the build env, NOT in the target Python's site-packages).
   3. The active conda env at CONDA_PREFIX/lib/libclang.so (used for
      `pip install -e . --no-build-isolation` against a conda dev env).
+
+With ``--print-resource-dir`` the script instead prints a clang *resource
+directory* (the dir holding the compiler builtin headers `stddef.h`,
+`xmmintrin.h`, …). The pip `libclang` wheel ships **no** such headers, so on
+platforms where libclang cannot auto-discover them (musllinux, macOS) the
+docstring parse fails on `cmath` / `*mmintrin.h`. Resolution order:
+  1. LIBCLANG_RESOURCE_DIR env var (explicit override).
+  2. ``<clang|clang-NN|xcrun clang> -print-resource-dir`` (a system clang).
+  3. System globs (`/usr/lib/clang/*`, `/usr/lib/llvm*/lib/clang/*`, …).
+  4. Relative to the discovered libclang library.
+An empty print means "use libclang's defaults" (correct on manylinux/Windows).
 """
 
 import argparse
 import glob
 import os
+import subprocess
 import sys
 import sysconfig
 from pathlib import Path
@@ -66,6 +78,61 @@ def candidates(extra_paths):
       yield from glob.glob(os.path.join(root, "**", pat), recursive=True)
 
 
+def _is_resource_dir(d):
+  # A usable resource dir has the builtin headers under include/.
+  return bool(d) and Path(d, "include", "stddef.h").is_file()
+
+
+def resource_dir_candidates(libclang_path):
+  override = os.environ.get("LIBCLANG_RESOURCE_DIR")
+  if override:
+    yield override
+
+  # A system clang knows its own resource dir. Try plain `clang`, versioned
+  # `clang-NN`, and macOS' `xcrun clang` (AppleClang lives inside the SDK).
+  clang_invocations = [["clang"], ["xcrun", "clang"]] + [
+    ["clang-{}".format(v)] for v in range(20, 13, -1)
+  ]
+  for inv in clang_invocations:
+    try:
+      out = subprocess.run(
+        inv + ["-print-resource-dir"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+      )
+    except (OSError, subprocess.SubprocessError):
+      continue
+    if out.returncode == 0 and out.stdout.strip():
+      yield out.stdout.strip()
+
+  # System install globs (newest first).
+  globs = [
+    "/usr/lib/clang/*",
+    "/usr/lib/llvm*/lib/clang/*",
+    "/usr/local/lib/clang/*",
+    "/usr/lib64/clang/*",
+  ]
+  for pat in globs:
+    for hit in sorted(glob.glob(pat), reverse=True):
+      yield hit
+
+  # Relative to the libclang shared library (some distributions co-locate the
+  # resource dir next to the .so).
+  if libclang_path:
+    libdir = Path(libclang_path).resolve().parent
+    for rel in ("clang", "../lib/clang", "../clang"):
+      for hit in sorted(glob.glob(str(libdir / rel / "*")), reverse=True):
+        yield hit
+
+
+def find_libclang(extra):
+  for c in candidates(extra):
+    if Path(c).is_file():
+      return c
+  return ""
+
+
 def main():
   parser = argparse.ArgumentParser(description=__doc__)
   parser.add_argument(
@@ -73,13 +140,28 @@ def main():
     default="",
     help="Semicolon-separated extra search paths (CMAKE_PREFIX_PATH).",
   )
+  parser.add_argument(
+    "--print-resource-dir",
+    action="store_true",
+    help="Print a clang resource dir (builtin headers) instead of the "
+    "libclang library path. Empty output means 'use libclang defaults'.",
+  )
   args = parser.parse_args()
   extra = [p for p in args.search_paths.split(";") if p]
 
-  for c in candidates(extra):
-    if Path(c).is_file():
-      sys.stdout.write(c)
-      return
+  if args.print_resource_dir:
+    libclang_path = find_libclang(extra)
+    for d in resource_dir_candidates(libclang_path):
+      if _is_resource_dir(d):
+        sys.stdout.write(d)
+        return
+    # Nothing printed -> CMake omits -resource-dir and libclang uses its
+    # own defaults (correct where auto-discovery already works).
+    return
+
+  path = find_libclang(extra)
+  if path:
+    sys.stdout.write(path)
   # No path printed -> CMake's existence check will produce a clear error.
 
 

--- a/scripts/find_libclang.py
+++ b/scripts/find_libclang.py
@@ -10,23 +10,11 @@ none found). Resolution order:
        in the build env, NOT in the target Python's site-packages).
   3. The active conda env at CONDA_PREFIX/lib/libclang.so (used for
      `pip install -e . --no-build-isolation` against a conda dev env).
-
-With ``--print-resource-dir`` the script instead prints a clang *resource
-directory* (the dir holding the compiler builtin headers `stddef.h`,
-`xmmintrin.h`, …). The pip `libclang` wheel ships **no** such headers, so on
-platforms where libclang cannot auto-discover them (musllinux, macOS) the
-docstring parse fails on `cmath` / `*mmintrin.h`. Resolution order:
-  1. LIBCLANG_RESOURCE_DIR env var (explicit override).
-  2. ``<clang|clang-NN|xcrun clang> -print-resource-dir`` (a system clang).
-  3. System globs (`/usr/lib/clang/*`, `/usr/lib/llvm*/lib/clang/*`, …).
-  4. Relative to the discovered libclang library.
-An empty print means "use libclang's defaults" (correct on manylinux/Windows).
 """
 
 import argparse
 import glob
 import os
-import subprocess
 import sys
 import sysconfig
 from pathlib import Path
@@ -78,61 +66,6 @@ def candidates(extra_paths):
       yield from glob.glob(os.path.join(root, "**", pat), recursive=True)
 
 
-def _is_resource_dir(d):
-  # A usable resource dir has the builtin headers under include/.
-  return bool(d) and Path(d, "include", "stddef.h").is_file()
-
-
-def resource_dir_candidates(libclang_path):
-  override = os.environ.get("LIBCLANG_RESOURCE_DIR")
-  if override:
-    yield override
-
-  # A system clang knows its own resource dir. Try plain `clang`, versioned
-  # `clang-NN`, and macOS' `xcrun clang` (AppleClang lives inside the SDK).
-  clang_invocations = [["clang"], ["xcrun", "clang"]] + [
-    ["clang-{}".format(v)] for v in range(20, 13, -1)
-  ]
-  for inv in clang_invocations:
-    try:
-      out = subprocess.run(
-        inv + ["-print-resource-dir"],
-        capture_output=True,
-        text=True,
-        timeout=30,
-      )
-    except (OSError, subprocess.SubprocessError):
-      continue
-    if out.returncode == 0 and out.stdout.strip():
-      yield out.stdout.strip()
-
-  # System install globs (newest first).
-  globs = [
-    "/usr/lib/clang/*",
-    "/usr/lib/llvm*/lib/clang/*",
-    "/usr/local/lib/clang/*",
-    "/usr/lib64/clang/*",
-  ]
-  for pat in globs:
-    for hit in sorted(glob.glob(pat), reverse=True):
-      yield hit
-
-  # Relative to the libclang shared library (some distributions co-locate the
-  # resource dir next to the .so).
-  if libclang_path:
-    libdir = Path(libclang_path).resolve().parent
-    for rel in ("clang", "../lib/clang", "../clang"):
-      for hit in sorted(glob.glob(str(libdir / rel / "*")), reverse=True):
-        yield hit
-
-
-def find_libclang(extra):
-  for c in candidates(extra):
-    if Path(c).is_file():
-      return c
-  return ""
-
-
 def main():
   parser = argparse.ArgumentParser(description=__doc__)
   parser.add_argument(
@@ -140,28 +73,13 @@ def main():
     default="",
     help="Semicolon-separated extra search paths (CMAKE_PREFIX_PATH).",
   )
-  parser.add_argument(
-    "--print-resource-dir",
-    action="store_true",
-    help="Print a clang resource dir (builtin headers) instead of the "
-    "libclang library path. Empty output means 'use libclang defaults'.",
-  )
   args = parser.parse_args()
   extra = [p for p in args.search_paths.split(";") if p]
 
-  if args.print_resource_dir:
-    libclang_path = find_libclang(extra)
-    for d in resource_dir_candidates(libclang_path):
-      if _is_resource_dir(d):
-        sys.stdout.write(d)
-        return
-    # Nothing printed -> CMake omits -resource-dir and libclang uses its
-    # own defaults (correct where auto-discovery already works).
-    return
-
-  path = find_libclang(extra)
-  if path:
-    sys.stdout.write(path)
+  for c in candidates(extra):
+    if Path(c).is_file():
+      sys.stdout.write(c)
+      return
   # No path printed -> CMake's existence check will produce a clear error.
 
 

--- a/scripts/generate_docstring.py
+++ b/scripts/generate_docstring.py
@@ -1670,6 +1670,15 @@ def parse_args():
     "not provided, in which case Eigen/Boost are looked up under "
     "~/miniforge3/envs/<env>/include[/eigen3].",
   )
+  parser.add_argument(
+    "--clang-arg",
+    dest="clang_args",
+    action="append",
+    default=[],
+    help="Extra argument passed verbatim to libclang (can be specified "
+    "multiple times). Use --clang-arg=-isysroot --clang-arg=<sdk> to pass "
+    "flag/value pairs without them being parsed as this tool's own options.",
+  )
   return parser.parse_args()
 
 
@@ -1696,6 +1705,9 @@ def main():
     f"-std={args.std}",
   ]
   parameters.extend([f"-I{inc}" for inc in args.include_dirs])
+  # Verbatim libclang args (e.g. -isysroot <sdk> on macOS). Appended early so
+  # an SDK sysroot is in effect before the -isystem dirs below are resolved.
+  parameters.extend(args.clang_args)
   if args.isystem_dirs:
     parameters.extend([f"-isystem{inc}" for inc in args.isystem_dirs])
   else:
@@ -1791,6 +1803,29 @@ def main():
       parameters,
       options=cindex.TranslationUnit.PARSE_DETAILED_PROCESSING_RECORD,
     )
+    # Fail loudly on fatal parse errors. A partial AST (e.g. when libclang
+    # cannot find the C++ standard library or Eigen/Boost headers) otherwise
+    # silently produces a docstr.hpp with whole symbols missing and overload
+    # names mis-disambiguated, which only surfaces later as cryptic
+    # "no member named ..." errors when the bindings are compiled. Surface
+    # the real cause here instead.
+    fatal = [
+      d
+      for d in translation_unit.diagnostics
+      if d.severity >= cindex.Diagnostic.Error
+    ]
+    if fatal:
+      eprint(
+        "libclang reported {} fatal diagnostic(s) while parsing the C++ "
+        "headers. The generated docstr.hpp would be incomplete (missing "
+        "symbols / mis-named overloads). This usually means the C++ standard "
+        "library or Eigen/Boost headers were not on the include path — pass "
+        "the host toolchain's system include dirs via -isystem (CMake does "
+        "this from CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES).".format(len(fatal))
+      )
+      for d in fatal:
+        eprint("  {}: {}".format(d.location, d.spelling))
+      sys.exit(1)
   shutil.rmtree(tmpdir)
   # Extract symbols.
   if not quiet:

--- a/scripts/generate_docstring.py
+++ b/scripts/generate_docstring.py
@@ -1803,16 +1803,23 @@ def main():
       parameters,
       options=cindex.TranslationUnit.PARSE_DETAILED_PROCESSING_RECORD,
     )
-    # Fail loudly on fatal parse errors. A partial AST (e.g. when libclang
-    # cannot find the C++ standard library or Eigen/Boost headers) otherwise
-    # silently produces a docstr.hpp with whole symbols missing and overload
-    # names mis-disambiguated, which only surfaces later as cryptic
-    # "no member named ..." errors when the bindings are compiled. Surface
-    # the real cause here instead.
+    # Fail loudly on *fatal* parse errors only. A fatal diagnostic (e.g. a
+    # missing C++ standard-library / Eigen / Boost header, or clang's
+    # "too many errors" stop) truncates the AST, so docstr.hpp would silently
+    # lose whole symbols and mis-disambiguate overloads — which only surfaces
+    # later as cryptic "no member named ..." compile errors. Surface that here.
+    #
+    # We deliberately do NOT abort on plain `error:`-severity diagnostics.
+    # libclang is not a full compiler, and parsing Eigen/Boost pulls in
+    # vendor intrinsic headers (xmmintrin.h, arm_neon.h, ...) whose builtins
+    # are version-specific; libclang emits ~100 harmless errors there. Those
+    # do not stop parsing or affect the *declarations* docstrings are read
+    # from. CMake passes `-ferror-limit=0` so this error noise never trips
+    # clang's default 20-error limit (which would itself become a fatal).
     fatal = [
       d
       for d in translation_unit.diagnostics
-      if d.severity >= cindex.Diagnostic.Error
+      if d.severity >= cindex.Diagnostic.Fatal
     ]
     if fatal:
       eprint(


### PR DESCRIPTION
The pip `libclang` wheel ships no builtin headers and does not auto-discover the C++ stdlib / compiler intrinsics on every platform, so docstr.hpp was silently generated with missing symbols / mis-named overloads on osx and musllinux — surfacing only as cryptic "no member named ..." compile errors.

- generate_docstring.py: abort on any fatal libclang diagnostic instead of emitting a partial header; add a --clang-arg passthrough.
- find_libclang.py: add --print-resource-dir to locate a clang resource dir (builtin/intrinsic headers the wheel lacks).
- CMakeLists.txt (non-MSVC only): feed libclang the compiler's filtered, normalized implicit system include dirs (dropping the gcc/clang builtin dirs whose intrinsics break clang) ordered before Eigen/Boost so a bare /usr/include from system Boost doesn't break <cmath>'s #include_next; a discovered clang -resource-dir; and the SDK sysroot on macOS.
- pypi.yml: `apk add clang` on musllinux (CIBW_BEFORE_ALL_LINUX, no-op elsewhere); migrate macOS CI to macos-15 + re-add macos-15-intel; EXPECTED_WHEEL_COUNT 12 -> 15.

Verified end-to-end in a real musllinux container (exit 0, all members).