### PR TITLE
Fix BicopFamily enum members missing from type stubs (#223)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Treat `pyvinecopulib`-originated `DeprecationWarning`s as errors under pytest so internal call sites stay on the canonical import paths (#207).
 - Install `--extra torch` in the notebook-test and regenerate-notebooks CI jobs so `examples/10_torch_backend.ipynb` executes under `nbmake` (#216).
 - Fix osx / musllinux wheel builds: feed libclang the compiler's implicit system include dirs (plus `-ferror-limit=0` and the macOS SDK sysroot) so the C++ stdlib / intrinsic headers resolve, and abort `docstr.hpp` generation only on *fatal* libclang diagnostics (intrinsic-header `error`s are benign and no longer silently drop symbols).
+- Fix Windows wheel builds against the VS 2026 / MSVC 14.51 STL: rewrite `__builtin_verbose_trap` to `__builtin_trap()` during `docstr.hpp` generation. The newer STL emits this Clang-18 builtin from core allocator / string / `call_once` headers, which the pinned PyPI libclang (≤18) can't resolve; because those headers reach nearly every translation unit, the broken parse crashed symbol extraction. Also narrow a numpy-scalar union in the `Kde1d` plot helper so `make check` (`ty`) passes (#224).
 - Migrate macOS CI to `macos-15` and re-add `macos-15-intel` (`MACOSX_DEPLOYMENT_TARGET=10.13` for nanobind's aligned `new`/`delete`); wheel matrix is now 5 platforms × 3 ABI (15 wheels).
 
 ### Bug fixes in `pyvinecopulib`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 ### Bug fixes in `pyvinecopulib`
 
 - Port the `integrate_2d` marginal-renormalisation fix to the torch backend (`InterpolationGrid2D.integrate_2d` and `integrate_2d_batched`) so `TorchBicop.cdf` enforces ``C(1, u_2) = u_2`` exactly, matching the post-vinecopulib#667 C++ CDF to machine precision on the on-the-fly path ([vinecopulib#667](https://github.com/vinecopulib/vinecopulib/pull/667)).
+- Declare `BicopFamily` enum members as class attributes in the generated type stubs so the documented `pv.BicopFamily.clayton` access pattern passes static type checking (`ty` / pyright / mypy), not only the module-level constants (#223).
 
 ### Dependency changes
 

--- a/scripts/generate_docstring.py
+++ b/scripts/generate_docstring.py
@@ -1704,6 +1704,17 @@ def main():
     # MSVC STL itself as the official escape hatch and is harmless on other
     # platforms (it just isn't referenced by libstdc++/libc++).
     "-D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH",
+    # Neutralise __builtin_verbose_trap. The VS 2026 / MSVC 14.51 STL emits
+    # this Clang-18 builtin from core allocator / string / call_once paths
+    # (xmemory, xstring, xcall_once), but PyPI's libclang 18.x does not
+    # resolve it ("use of undeclared identifier"). Because those headers are
+    # pulled into nearly every translation unit, the resulting broken AST
+    # crashes symbol extraction (exit -1) rather than just emitting harmless
+    # diagnostics. Rewrite calls to the universally-supported __builtin_trap()
+    # so parsing succeeds; the variadic macro only expands at call sites
+    # (`name(`), so `__has_builtin(__builtin_verbose_trap)` is unaffected, and
+    # the rewrite is inert on platforms whose STL never references it.
+    "-D__builtin_verbose_trap(...)=__builtin_trap()",
     f"-std={args.std}",
   ]
   parameters.extend([f"-I{inc}" for inc in args.include_dirs])

--- a/scripts/generate_stubs.py
+++ b/scripts/generate_stubs.py
@@ -170,6 +170,12 @@ def render_class_stub(
         lines.append(
           f"{inner_indent}def {attr_name}(self, value: Any) -> None: ..."
         )
+    elif isinstance(attr, cls):
+      # Enum member exposed as a class attribute (e.g. ``BicopFamily.clayton``).
+      # Declare it inside the class body so ``Cls.member`` type-checks; the
+      # module-level constants from ``.export_values()`` are emitted separately
+      # by ``generate_stub``.
+      lines.append(f"{inner_indent}{attr_name}: {name} = ...")
 
   lines.append("")  # Final newline
   return lines

--- a/src/pyvinecopulib/_python_helpers/kde1d.py
+++ b/src/pyvinecopulib/_python_helpers/kde1d.py
@@ -130,13 +130,18 @@ def kde1d_plot(
       if isinstance(xmax_val, np.ndarray):
         xmax_val = float(xmax_val) if xmax_val.size > 0 else np.nan
 
+      # Narrow with isinstance against real numeric types (not
+      # np.isscalar, which doesn't narrow for ty and leaves complex /
+      # str in the union, so float() below is rejected). This also
+      # excludes non-finite values via the np.isfinite guard.
+      real_scalar = (int, float, np.floating, np.integer)
       if (
-        np.isscalar(xmin_val)
-        and np.isscalar(xmax_val)
+        isinstance(xmin_val, real_scalar)
+        and isinstance(xmax_val, real_scalar)
         and np.isfinite(xmin_val)
         and np.isfinite(xmax_val)
       ):
-        plt.xlim(xmin_val, xmax_val)
+        plt.xlim(float(xmin_val), float(xmax_val))
       else:
         x_range = ev.max() - ev.min()
         plt.xlim(ev.min() - 0.05 * x_range, ev.max() + 0.05 * x_range)

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -1,0 +1,43 @@
+"""Tests for the `.pyi` stub generator (`scripts/generate_stubs.py`).
+
+The generator is a build-time helper, not part of the installed package, so it
+is loaded by file path. These tests guard the rendered output rather than the
+gitignored stub artifacts on disk.
+"""
+
+import importlib.util
+from pathlib import Path
+
+from pyvinecopulib.families import BicopFamily
+
+_SCRIPTS = (
+  Path(__file__).resolve().parent.parent / "scripts" / "generate_stubs.py"
+)
+
+
+def _load_generator():
+  spec = importlib.util.spec_from_file_location("generate_stubs", _SCRIPTS)
+  assert spec is not None and spec.loader is not None
+  mod = importlib.util.module_from_spec(spec)
+  spec.loader.exec_module(mod)
+  return mod
+
+
+def test_bicopfamily_members_rendered_as_class_attributes():
+  """Enum members are declared inside the class body (see issue #223).
+
+  ``pv.BicopFamily.clayton`` is the documented access pattern; the stub must
+  declare each member as a typed class attribute so it passes static type
+  checking, not only as a module-level constant.
+  """
+  gen = _load_generator()
+  body = "\n".join(gen.render_class_stub(BicopFamily, "BicopFamily"))
+  members = [
+    n
+    for n in dir(BicopFamily)
+    if not n.startswith("_")
+    and isinstance(getattr(BicopFamily, n), BicopFamily)
+  ]
+  assert members  # sanity: the enum exposes members
+  for m in members:
+    assert f"  {m}: BicopFamily = ..." in body


### PR DESCRIPTION
Fixes #223.

## Problem

`pv.BicopFamily.clayton` — the access pattern shown throughout the docs and
examples — works at runtime but fails static type checking ("Class
`BicopFamily` has no attribute `clayton`") under `ty` / pyright / mypy. The
generated `.pyi` declared `BicopFamily` as an empty class and emitted its
members only as module-level constants.

## Root cause

`.pyi` stubs are produced by `scripts/generate_stubs.py` (a custom generator,
not nanobind's `stubgen`). Its `render_class_stub()` only emitted methods and
properties. `BicopFamily` is a real `enum.Enum` subclass whose members are
*instances* of the class — neither callable nor descriptors — so they fell
through both branches and were dropped from the class body.

## Fix

Add an `isinstance(attr, cls)` branch in `render_class_stub` that declares each
enum member as a typed class attribute (`clayton: BicopFamily = ...`) inside the
class body. The module-level constants are left untouched, so both access paths
stay valid. The change is general for any bound nanobind enum; the top-level and
`core` stubs re-export `BicopFamily` from `families`, so all three consumers are
fixed by the single change.

## Verification

- Regenerated `families/__init__.pyi` now declares all 13 members in the class
  body **and** keeps the module-level constants.
- `ty` reveals `pv.BicopFamily.clayton` as `BicopFamily` with no "has no
  attribute" error.
- New `tests/test_stubs.py` guards the rendered output; `make check` (ruff +
  ty + bandit) passes.