### PR TITLE
feat(core): custom tree_criterion function for vine structure selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Flip torch defaults based on a bicop + vine benchmark sweep: `cache_integrals=True` everywhere (80–300× faster `cdf` / `hfunc` / `hinv` on cpu, 2–80× on cuda), `batched` resolves device-aware via `_default_batched()` (`True` on cuda, `False` on cpu) (#219).
 - Add a tutorial-style `docs/concepts.rst` introducing Sklar's theorem, pair-copula construction, R-vines, and the TLL family in a ~5-minute read (#218).
 - Use Sphinx autosummary on the four subpackage landing pages so module docstrings, classes, and free functions get their own indexed pages (#214).
+- Add a custom `tree_criterion` for vine structure selection: set `FitControlsVinecop(tree_criterion="custom")` and supply `tree_criterion_function`, a callable `f(data, weights) -> float` mapping a two-column array of pair pseudo-observations (and observation weights) to a scalar edge weight (its absolute value is used). The callable round-trips through pickle when it is picklable (e.g. a module-level function); calls acquire the GIL, so they serialise under `num_threads > 1` ([vinecopulib#674](https://github.com/vinecopulib/vinecopulib/pull/674)).
 
 ### Build / packaging
 
@@ -56,6 +57,7 @@
 - Early exit in vine selection when the structure is already a tree, avoiding redundant work in `select` ([vinecopulib#661](https://github.com/vinecopulib/vinecopulib/pull/661)).
 - Per-family parameter / rotation / tail-dependence documentation on the `BicopFamily` enum members, surfaced through the Python `families` subpackage (#214, [vinecopulib#668](https://github.com/vinecopulib/vinecopulib/pull/668)).
 - Numpydoc-compliant `//!` comments on every property getter / setter in the Python-binding surface, surfaced through the pyvinecopulib autosummary pages (#214, [vinecopulib#670](https://github.com/vinecopulib/vinecopulib/pull/670)).
+- Allow a custom `tree_criterion` function for vine structure selection ([vinecopulib#674](https://github.com/vinecopulib/vinecopulib/pull/674)).
 
 #### BUG FIXES
 

--- a/src/include/vinecop/fit_controls.hpp
+++ b/src/include/vinecop/fit_controls.hpp
@@ -2,6 +2,8 @@
 
 #include <nanobind/eigen/dense.h>
 #include <nanobind/nanobind.h>
+#include <nanobind/stl/function.h>
+#include <nanobind/stl/optional.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/tuple.h>
 #include <nanobind/stl/vector.h>
@@ -70,6 +72,23 @@ inline void init_vinecop_fit_controls(nb::module_& module) {
       .def_prop_rw("tree_criterion", &FitControlsVinecop::get_tree_criterion,
                    &FitControlsVinecop::set_tree_criterion,
                    fitcontrolsvinecop_doc.get_tree_criterion.doc)
+      .def_prop_rw(
+          "tree_criterion_function",
+          [](const FitControlsVinecop& controls)
+              -> std::optional<TreeCriterionFunction> {
+            auto f = controls.get_tree_criterion_function();
+            if (!f) {
+              return std::nullopt;
+            }
+            return f;
+          },
+          [](FitControlsVinecop& controls,
+             std::optional<TreeCriterionFunction> tree_criterion_function) {
+            controls.set_tree_criterion_function(tree_criterion_function
+                                                     ? *tree_criterion_function
+                                                     : TreeCriterionFunction{});
+          },
+          fitcontrolsvinecop_doc.get_tree_criterion_function.doc)
       .def_prop_rw("threshold", &FitControlsVinecop::get_threshold,
                    &FitControlsVinecop::set_threshold,
                    fitcontrolsvinecop_doc.get_threshold.doc)
@@ -143,6 +162,10 @@ inline void init_vinecop_fit_controls(nb::module_& module) {
                  controls.get_nonparametric_grid_size();
              state["trunc_lvl"] = controls.get_trunc_lvl();
              state["tree_criterion"] = controls.get_tree_criterion();
+             // Empty std::function casts to None; a wrapped Python callable
+             // casts back to the original object (picklable if module-level).
+             state["tree_criterion_function"] =
+                 controls.get_tree_criterion_function();
              state["threshold"] = controls.get_threshold();
              state["selection_criterion"] = controls.get_selection_criterion();
              state["weights"] = controls.get_weights();
@@ -173,6 +196,12 @@ inline void init_vinecop_fit_controls(nb::module_& module) {
             nb::cast<std::size_t>(state["nonparametric_grid_size"]);
         config.trunc_lvl = nb::cast<std::size_t>(state["trunc_lvl"]);
         config.tree_criterion = nb::cast<std::string>(state["tree_criterion"]);
+        // Guard the key so pre-feature pickles (without it) still load.
+        if (state.contains("tree_criterion_function") &&
+            !state["tree_criterion_function"].is_none()) {
+          config.tree_criterion_function =
+              nb::cast<TreeCriterionFunction>(state["tree_criterion_function"]);
+        }
         config.threshold = nb::cast<double>(state["threshold"]);
         config.selection_criterion =
             nb::cast<std::string>(state["selection_criterion"]);

--- a/tests/test_pickling.py
+++ b/tests/test_pickling.py
@@ -1,6 +1,7 @@
 import pickle
 
 import numpy as np
+import pytest
 
 import pyvinecopulib as pv
 
@@ -12,6 +13,11 @@ from .helpers import (
   compare_vinecop,
   random_data,
 )
+
+
+def _custom_criterion(data: np.ndarray, weights: np.ndarray) -> float:
+  # Module-level (hence picklable) custom tree criterion.
+  return float(pv.utils.wdm(data[:, 0], data[:, 1], "tau"))
 
 
 def test_fitcontrolsbicop() -> None:
@@ -63,6 +69,7 @@ def test_fitcontrolsvinecop() -> None:
     "nonparametric_grid_size",
     "trunc_lvl",
     "tree_criterion",
+    "tree_criterion_function",
     "threshold",
     "selection_criterion",
     "psi0",
@@ -77,6 +84,22 @@ def test_fitcontrolsvinecop() -> None:
     "seeds",
   ]
   compare_properties(original_controls, deserialized_controls, attrs)
+
+
+def test_fitcontrolsvinecop_custom_criterion() -> None:
+  # A module-level custom criterion round-trips by reference; the getter
+  # returns the same object after unpickling.
+  original_controls = pv.FitControlsVinecop(tree_criterion="custom")
+  original_controls.tree_criterion_function = _custom_criterion
+
+  deserialized_controls = pickle.loads(pickle.dumps(original_controls))
+  assert deserialized_controls.tree_criterion == "custom"
+  assert deserialized_controls.tree_criterion_function is _custom_criterion
+
+  # A non-picklable callable (lambda) raises the standard pickling error.
+  original_controls.tree_criterion_function = lambda data, weights: 0.0
+  with pytest.raises((pickle.PicklingError, AttributeError)):
+    pickle.dumps(original_controls)
 
 
 def test_bicop() -> None:

--- a/tests/test_vinecop.py
+++ b/tests/test_vinecop.py
@@ -1,10 +1,24 @@
 import os
 
 import numpy as np
+import pytest
 
 import pyvinecopulib as pv
 
 from .helpers import compare_vinecop, random_data
+
+
+def _wdm_tau(data: np.ndarray, weights: np.ndarray) -> float:
+  # Reproduce the built-in "tau" edge weight (signed Kendall's tau). The
+  # selector applies abs() and the sqrt(freq) factor on top, so a custom
+  # function returning signed tau yields the same structure as "tau".
+  if weights.size:
+    return float(pv.utils.wdm(data[:, 0], data[:, 1], "tau", weights=weights))
+  return float(pv.utils.wdm(data[:, 0], data[:, 1], "tau"))
+
+
+def _raising_criterion(data: np.ndarray, weights: np.ndarray) -> float:
+  raise ValueError("custom criterion failure")
 
 
 def test_vinecop(unique_json_path: str) -> None:
@@ -100,3 +114,87 @@ def test_vinecop(unique_json_path: str) -> None:
   cop.to_file(filename)
   new_cop = pv.Vinecop.from_file(filename)
   compare_vinecop(cop, new_cop)
+
+
+def test_custom_criterion_matches_builtin_tau() -> None:
+  # A custom function returning signed Kendall's tau must reproduce the
+  # structure selected by the built-in "tau" criterion exactly.
+  d, n = 5, 1000
+  u = pv.to_pseudo_obs(random_data(d, n))
+
+  cop_tau = pv.Vinecop.from_data(
+    u, controls=pv.FitControlsVinecop(tree_criterion="tau")
+  )
+
+  controls = pv.FitControlsVinecop(tree_criterion="custom")
+  controls.tree_criterion_function = _wdm_tau
+  cop_custom = pv.Vinecop.from_data(u, controls=controls)
+
+  assert np.array_equal(cop_tau.matrix, cop_custom.matrix)
+  assert cop_tau.order == cop_custom.order
+
+
+def test_tree_criterion_custom_accepted() -> None:
+  # Regression that the submodule bump exposes the "custom" criterion.
+  controls = pv.FitControlsVinecop()
+  controls.tree_criterion = "custom"
+  assert controls.tree_criterion == "custom"
+
+
+def test_tree_criterion_function_roundtrip_property() -> None:
+  controls = pv.FitControlsVinecop()
+  assert controls.tree_criterion_function is None
+  controls.tree_criterion_function = _wdm_tau
+  # The getter hands back the original Python callable.
+  assert controls.tree_criterion_function is _wdm_tau
+  controls.tree_criterion_function = None
+  assert controls.tree_criterion_function is None
+
+
+def test_custom_criterion_unset_raises() -> None:
+  d, n = 5, 300
+  u = pv.to_pseudo_obs(random_data(d, n))
+  controls = pv.FitControlsVinecop(tree_criterion="custom")
+  with pytest.raises(RuntimeError):
+    pv.Vinecop.from_data(u, controls=controls)
+
+
+def test_custom_criterion_ignored_when_not_custom() -> None:
+  # A function set while tree_criterion != "custom" is never called.
+  d, n = 5, 1000
+  u = pv.to_pseudo_obs(random_data(d, n))
+
+  controls = pv.FitControlsVinecop(tree_criterion="tau")
+  controls.tree_criterion_function = _raising_criterion  # must be ignored
+  cop_custom = pv.Vinecop.from_data(u, controls=controls)
+
+  cop_tau = pv.Vinecop.from_data(
+    u, controls=pv.FitControlsVinecop(tree_criterion="tau")
+  )
+  assert np.array_equal(cop_tau.matrix, cop_custom.matrix)
+
+
+def test_custom_criterion_exception_propagates() -> None:
+  # A Python exception raised inside the criterion surfaces from from_data.
+  d, n = 5, 1000
+  u = pv.to_pseudo_obs(random_data(d, n))
+  controls = pv.FitControlsVinecop(tree_criterion="custom", num_threads=1)
+  controls.tree_criterion_function = _raising_criterion
+  with pytest.raises(ValueError):
+    pv.Vinecop.from_data(u, controls=controls)
+
+
+def test_custom_criterion_multithread_smoke() -> None:
+  # Calls acquire the GIL, so num_threads > 1 must still give the same result.
+  d, n = 5, 1000
+  u = pv.to_pseudo_obs(random_data(d, n))
+
+  c1 = pv.FitControlsVinecop(tree_criterion="custom", num_threads=1)
+  c1.tree_criterion_function = _wdm_tau
+  cop1 = pv.Vinecop.from_data(u, controls=c1)
+
+  c2 = pv.FitControlsVinecop(tree_criterion="custom", num_threads=2)
+  c2.tree_criterion_function = _wdm_tau
+  cop2 = pv.Vinecop.from_data(u, controls=c2)
+
+  assert np.array_equal(cop1.matrix, cop2.matrix)


### PR DESCRIPTION
Bind the upstream vinecopulib#674 custom tree-criterion API on FitControlsVinecop. Users can now grow the vine structure with an arbitrary edge-weight callable instead of the built-in string criteria:

    controls = pv.FitControlsVinecop(tree_criterion="custom")
    controls.tree_criterion_function = my_crit  # f(data, weights) -> float

- Add a `tree_criterion_function` read/write property (property-only; the positional constructor is left untouched, mirroring #674 which does not add the function to the C++ constructor). nanobind's std::function caster acquires the GIL on each call, so invocation from the GIL-released, multithreaded fit is safe.
- Pickling: store the original callable via __getstate__/__setstate__. Picklable callables (module-level functions) round-trip; lambdas raise the standard PicklingError. The __setstate__ key is guarded so pre-feature pickles still load.
- Bump lib/vinecopulib to 263039c (feat/custom-tree-criterion, the head of vinecopulib#674). NOTE: this is an unmerged upstream branch and must be re-pinned to the merged commit before this PR lands. The SHA is the head of a real branch in the upstream repo, so CI submodule init can fetch it.

Tests: parity (a custom function returning signed Kendall's tau reproduces the built-in "tau" structure exactly), property round-trip, custom-without-function raises, function-ignored-when-not-custom, exception propagation, multithread smoke, and pickling round-trip.