### PR TITLE
Per-row parameters for Bicop pdf/cdf/hfunc/hinv/loglik (vinecopulib#675)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Add a tutorial-style `docs/concepts.rst` introducing Sklar's theorem, pair-copula construction, R-vines, and the TLL family in a ~5-minute read (#218).
 - Use Sphinx autosummary on the four subpackage landing pages so module docstrings, classes, and free functions get their own indexed pages (#214).
 - Add a custom `tree_criterion` for vine structure selection: set `FitControlsVinecop(tree_criterion="custom")` and supply `tree_criterion_function`, a callable `f(data, weights) -> float` mapping a two-column array of pair pseudo-observations (and observation weights) to a scalar edge weight (its absolute value is used). The callable round-trips through pickle when it is picklable (e.g. a module-level function); calls acquire the GIL, so they serialise under `num_threads > 1` ([vinecopulib#674](https://github.com/vinecopulib/vinecopulib/pull/674)).
+- Add per-row-parameter overloads of `Bicop.pdf` / `cdf` / `hfunc1` / `hfunc2` / `hinv1` / `hinv2` / `loglik`: pass an `(n, p)` array of `parameters` (one row per observation, `p` family parameters each) plus an optional `num_threads` to evaluate the copula with a different parameter set per row in a single (optionally threaded) call, instead of reusing the object's stored parameters. Parametric families only ([vinecopulib#675](https://github.com/vinecopulib/vinecopulib/pull/675)).
 
 ### Build / packaging
 
@@ -58,9 +59,11 @@
 - Per-family parameter / rotation / tail-dependence documentation on the `BicopFamily` enum members, surfaced through the Python `families` subpackage (#214, [vinecopulib#668](https://github.com/vinecopulib/vinecopulib/pull/668)).
 - Numpydoc-compliant `//!` comments on every property getter / setter in the Python-binding surface, surfaced through the pyvinecopulib autosummary pages (#214, [vinecopulib#670](https://github.com/vinecopulib/vinecopulib/pull/670)).
 - Allow a custom `tree_criterion` function for vine structure selection ([vinecopulib#674](https://github.com/vinecopulib/vinecopulib/pull/674)).
+- Per-row parameter evaluation for parametric bivariate copulas: `Bicop::pdf` / `cdf` / `hfunc1` / `hfunc2` / `hinv1` / `hinv2` / `loglik` gain an overload taking an `n×p` parameter matrix (one set per observation) plus an optional thread count, backed by an eval-core refactor to a single parameter-aware leaf per family ([vinecopulib#675](https://github.com/vinecopulib/vinecopulib/pull/675)).
 
 #### BUG FIXES
 
+- Fix an out-of-bounds read in the mixed discrete/continuous h-inverse (`hinv2` for `{d, c}` copulas with a numeric inverse: Frank, BB1/6/7/8, Tawn) ([vinecopulib#675](https://github.com/vinecopulib/vinecopulib/pull/675)).
 - Fix `integrade_2d` numerical handling on the bivariate-copula CDF path ([vinecopulib#667](https://github.com/vinecopulib/vinecopulib/pull/667)).
 - Fix a typo in `pdf_d_d` and tighten the threshold under which the analytical derivative is preferred over the finite-difference fallback ([vinecopulib#664](https://github.com/vinecopulib/vinecopulib/pull/664)).
 - Drop an unused fit-controls option ([vinecopulib#662](https://github.com/vinecopulib/vinecopulib/pull/662)).

--- a/src/include/bicop/class.hpp
+++ b/src/include/bicop/class.hpp
@@ -2,6 +2,7 @@
 
 #include <nanobind/eigen/dense.h>
 #include <nanobind/nanobind.h>
+#include <nanobind/stl/optional.h>
 #include <nanobind/stl/tuple.h>
 
 #include <vinecopulib.hpp>
@@ -67,6 +68,58 @@ Alternatives to instantiate bivariate copulas are:
 - ``Bicop.from_json()``: Instantiate from a JSON string.
 )""";
 
+  // `pdf` / `cdf` / `hfunc*` / `hinv*` / `loglik` each expose an optional
+  // `parameters` argument (vinecopulib#675): when omitted the copula's stored
+  // parameters are used (the original behaviour); when given an (n, p) matrix
+  // they are evaluated with a different parameter set per row of `u`. They are
+  // bound as a single Python method (rather than two overloads) so the
+  // generated `.pyi` stub carries the full signature. The base docstring is the
+  // libclang-extracted one for the stored-parameter form, extended with a note
+  // describing the per-row form.
+  const std::string per_row_note =
+      R"""(
+
+Notes
+-----
+If ``parameters`` is given, the copula is evaluated with a different parameter
+set per row of ``u`` instead of the stored parameters. ``parameters`` is then an
+``(n, p)`` array with one row per row of ``u`` and ``p == len(self.parameters)``
+columns, in the family's natural (unrotated) parameterization, and the
+evaluation may be parallelized over ``num_threads``. This is supported for
+parametric families only; a nonparametric family, a wrong shape, or non-finite
+or out-of-bounds values raise ``RuntimeError``.
+)""";
+  const std::string pdf_doc =
+      std::string(bicop_doc.pdf.doc_1args) + per_row_note;
+  const std::string cdf_doc =
+      std::string(bicop_doc.cdf.doc_1args) + per_row_note;
+  const std::string hfunc1_doc =
+      std::string(bicop_doc.hfunc1.doc_1args) + per_row_note;
+  const std::string hfunc2_doc =
+      std::string(bicop_doc.hfunc2.doc_1args) + per_row_note;
+  const std::string hinv1_doc =
+      std::string(bicop_doc.hinv1.doc_1args) + per_row_note;
+  const std::string hinv2_doc =
+      std::string(bicop_doc.hinv2.doc_1args) + per_row_note;
+  const std::string loglik_doc =
+      std::string(bicop_doc.loglik.doc_1args) + per_row_note;
+
+  // Dispatch helpers: pick the stored-parameter or per-row overload depending
+  // on whether `parameters` was supplied. Argument conversion (incl. the
+  // ndarray -> Eigen copy) happens before the GIL is released, so the lambda
+  // bodies only touch C++ types.
+  auto eval_with_optional_params =
+      [](Eigen::VectorXd (Bicop::*one)(const Eigen::MatrixXd&) const,
+         Eigen::VectorXd (Bicop::*many)(const Eigen::MatrixXd&,
+                                        const Eigen::MatrixXd&, size_t) const) {
+        return [one, many](const Bicop& self, const Eigen::MatrixXd& u,
+                           const std::optional<Eigen::MatrixXd>& parameters,
+                           size_t num_threads) -> Eigen::VectorXd {
+          if (parameters) return (self.*many)(u, *parameters, num_threads);
+          return (self.*one)(u);
+        };
+      };
+
   nb::class_<Bicop>(module, "Bicop", bicop_doc.doc)
       // Default constructor
       .def(nb::init<const BicopFamily, const int,
@@ -113,9 +166,17 @@ Alternatives to instantiate bivariate copulas are:
       .def_prop_ro("family", &Bicop::get_family, bicop_doc.get_family.doc)
       .def_prop_ro("tau", &Bicop::get_tau, bicop_doc.get_tau.doc)
       .def_prop_ro("npars", &Bicop::get_npars, bicop_doc.get_npars.doc)
-      .def("loglik", &Bicop::loglik,
-           "u"_a = Eigen::Matrix<double, Eigen::Dynamic, 2>(),
-           bicop_doc.loglik.doc, nb::call_guard<nb::gil_scoped_release>())
+      .def(
+          "loglik",
+          [](const Bicop& self, const Eigen::MatrixXd& u,
+             const std::optional<Eigen::MatrixXd>& parameters,
+             size_t num_threads) -> double {
+            if (parameters) return self.loglik(u, *parameters, num_threads);
+            return self.loglik(u);
+          },
+          "u"_a = Eigen::Matrix<double, Eigen::Dynamic, 2>(),
+          "parameters"_a = nb::none(), "num_threads"_a = static_cast<size_t>(1),
+          loglik_doc.c_str(), nb::call_guard<nb::gil_scoped_release>())
       .def_prop_ro("nobs", &Bicop::get_nobs, bicop_doc.get_nobs.doc)
       .def("aic", &Bicop::aic,
            "u"_a = Eigen::Matrix<double, Eigen::Dynamic, 2>(),
@@ -152,17 +213,29 @@ Alternatives to instantiate bivariate copulas are:
                    &Bicop::get_parameters_upper_bounds,
                    bicop_doc.get_parameters_upper_bounds.doc,
                    nb::call_guard<nb::gil_scoped_release>())
-      .def("pdf", &Bicop::pdf, "u"_a, bicop_doc.pdf.doc,
+      .def("pdf", eval_with_optional_params(&Bicop::pdf, &Bicop::pdf), "u"_a,
+           "parameters"_a = nb::none(),
+           "num_threads"_a = static_cast<size_t>(1), pdf_doc.c_str(),
            nb::call_guard<nb::gil_scoped_release>())
-      .def("cdf", &Bicop::cdf, "u"_a, bicop_doc.cdf.doc,
+      .def("cdf", eval_with_optional_params(&Bicop::cdf, &Bicop::cdf), "u"_a,
+           "parameters"_a = nb::none(),
+           "num_threads"_a = static_cast<size_t>(1), cdf_doc.c_str(),
            nb::call_guard<nb::gil_scoped_release>())
-      .def("hfunc1", &Bicop::hfunc1, "u"_a, bicop_doc.hfunc1.doc,
+      .def("hfunc1", eval_with_optional_params(&Bicop::hfunc1, &Bicop::hfunc1),
+           "u"_a, "parameters"_a = nb::none(),
+           "num_threads"_a = static_cast<size_t>(1), hfunc1_doc.c_str(),
            nb::call_guard<nb::gil_scoped_release>())
-      .def("hfunc2", &Bicop::hfunc2, "u"_a, bicop_doc.hfunc2.doc,
+      .def("hfunc2", eval_with_optional_params(&Bicop::hfunc2, &Bicop::hfunc2),
+           "u"_a, "parameters"_a = nb::none(),
+           "num_threads"_a = static_cast<size_t>(1), hfunc2_doc.c_str(),
            nb::call_guard<nb::gil_scoped_release>())
-      .def("hinv1", &Bicop::hinv1, "u"_a, bicop_doc.hinv1.doc,
+      .def("hinv1", eval_with_optional_params(&Bicop::hinv1, &Bicop::hinv1),
+           "u"_a, "parameters"_a = nb::none(),
+           "num_threads"_a = static_cast<size_t>(1), hinv1_doc.c_str(),
            nb::call_guard<nb::gil_scoped_release>())
-      .def("hinv2", &Bicop::hinv2, "u"_a, bicop_doc.hinv2.doc,
+      .def("hinv2", eval_with_optional_params(&Bicop::hinv2, &Bicop::hinv2),
+           "u"_a, "parameters"_a = nb::none(),
+           "num_threads"_a = static_cast<size_t>(1), hinv2_doc.c_str(),
            nb::call_guard<nb::gil_scoped_release>())
       .def("simulate", &Bicop::simulate, "n"_a, "qrng"_a = false,
            "seeds"_a = std::vector<int>(), bicop_doc.simulate.doc,

--- a/tests/test_bicop.py
+++ b/tests/test_bicop.py
@@ -129,3 +129,106 @@ def test_bicop(unique_json_path: str) -> None:
   # Test select method
   controls = pv.FitControlsBicop()
   bicop.select(u, controls)
+
+
+_PER_ROW_METHODS = ["pdf", "cdf", "hfunc1", "hfunc2", "hinv1", "hinv2"]
+
+
+def _per_row_params(
+  cop: pv.Bicop, n: int, rng: np.random.RandomState
+) -> np.ndarray:
+  """Build an (n, p) matrix of valid per-row parameters around ``cop``'s."""
+  base = cop.parameters.ravel()
+  p = base.shape[0]
+  return base[None, :] * (1.0 + 0.1 * rng.uniform(-1.0, 1.0, size=(n, p)))
+
+
+@pytest.mark.parametrize(
+  ("family", "parameters", "rotation"),
+  [
+    (pv.families.clayton, np.array([[2.0]]), 0),
+    (pv.families.clayton, np.array([[2.5]]), 90),
+    (pv.families.bb1, np.array([[1.0], [1.5]]), 0),
+  ],
+)
+def test_bicop_per_row_parameters(
+  family: pv.BicopFamily, parameters: np.ndarray, rotation: int
+) -> None:
+  rng = np.random.RandomState(42)
+  n = 50
+  u = rng.uniform(0.05, 0.95, size=(n, 2))
+  cop = pv.Bicop(family=family, rotation=rotation, parameters=parameters)
+  p = cop.parameters.shape[0]
+  pars = _per_row_params(cop, n, rng)
+  pars_const = np.tile(cop.parameters.ravel(), (n, 1))
+
+  for method in _PER_ROW_METHODS:
+    fn = getattr(cop, method)
+    # Shape: (n, 2) data + (n, p) parameters -> (n,) output.
+    values = fn(u, pars)
+    assert isinstance(values, np.ndarray)
+    assert values.shape == (n,)
+
+    # Identity parity: constant per-row parameters equal to the object's own
+    # parameters reproduce the state-based (single-argument) result.
+    np.testing.assert_allclose(fn(u, pars_const), fn(u), rtol=1e-9, atol=1e-12)
+
+    # Threading must not change the result.
+    np.testing.assert_allclose(
+      fn(u, pars, num_threads=2), values, rtol=1e-12, atol=1e-14
+    )
+
+    # Strong per-row parity: row i with parameters pars[i] equals a fresh
+    # copula built with those parameters evaluated at row i.
+    for i in (0, n // 2, n - 1):
+      single = pv.Bicop(
+        family=family, rotation=rotation, parameters=pars[i].reshape(p, 1)
+      )
+      np.testing.assert_allclose(
+        values[i], getattr(single, method)(u[i : i + 1])[0], rtol=1e-9
+      )
+
+  # loglik with per-row parameters: scalar, NaN-ignoring sum of log-densities,
+  # and matches the state-based loglik under constant parameters.
+  ll = cop.loglik(u, pars)
+  assert isinstance(ll, float)
+  np.testing.assert_allclose(ll, np.nansum(np.log(cop.pdf(u, pars))), rtol=1e-9)
+  np.testing.assert_allclose(
+    cop.loglik(u, pars_const), cop.loglik(u), rtol=1e-9, atol=1e-12
+  )
+
+
+def test_bicop_per_row_parameters_errors() -> None:
+  rng = np.random.RandomState(0)
+  n = 20
+  u = rng.uniform(0.05, 0.95, size=(n, 2))
+  cop = pv.Bicop(family=pv.families.clayton, parameters=np.array([[2.0]]))
+  pars = _per_row_params(cop, n, rng)
+
+  # Nonparametric families are not supported.
+  data = rng.uniform(size=(200, 2))
+  tll = pv.Bicop.from_data(
+    data, pv.FitControlsBicop(family_set=[pv.families.tll])
+  )
+  with pytest.raises(RuntimeError):
+    tll.pdf(u, np.ones((n, 1)))
+
+  # Wrong number of parameter rows (must equal u.rows()).
+  with pytest.raises(RuntimeError):
+    cop.pdf(u, pars[:-1])
+
+  # Wrong number of parameter columns (must equal the family's parameter count).
+  with pytest.raises(RuntimeError):
+    cop.pdf(u, np.ones((n, 2)))
+
+  # Non-finite parameters are rejected.
+  pars_nan = pars.copy()
+  pars_nan[0, 0] = np.nan
+  with pytest.raises(RuntimeError):
+    cop.pdf(u, pars_nan)
+
+  # Out-of-bounds parameters are rejected.
+  pars_oob = pars.copy()
+  pars_oob[0, 0] = -5.0
+  with pytest.raises(RuntimeError):
+    cop.pdf(u, pars_oob)


### PR DESCRIPTION
## Per-row parameters for `Bicop` (core)

Exposes the per-row-parameter evaluation from vinecopulib#675 on the core `Bicop`:
`pdf`, `cdf`, `hfunc1`, `hfunc2`, `hinv1`, `hinv2`, and `loglik` now take an optional
`parameters` array (shape `(n, p)`, one set per row of `u`) plus `num_threads`, evaluating
the copula at a different parameter set per observation in one (optionally threaded) call.
Parametric families only; omitting `parameters` keeps the existing stored-parameter behavior.

```python
cop = pv.Bicop(family=pv.families.clayton, parameters=np.array([[2.0]]))
theta = np.random.uniform(1.0, 5.0, size=(n, 1))   # one parameter row per observation
cop.pdf(u, theta)   # per-row densities (num_threads optional)
cop.pdf(u)          # unchanged: uses stored parameters
```

### Design

Each method is bound as a **single merged signature** `f(u, parameters=None, num_threads=1)`
that dispatches internally to the stored-parameter or per-row C++ overload (rather than two
nanobind overloads). This keeps the generated `.pyi` stub complete (`ty`-correct) and
preserves the canonical libclang docstring, extended with a `Notes` section. Argument
conversion happens before the GIL is released, so the dispatch lambdas only touch C++ types.

### Submodule

Bumps `lib/vinecopulib` to the `feat/bicop-per-row-parameters` head (`4cfabdc`), which also
brings the eval-core refactor (one parameter-aware leaf per family) and a fix for an
out-of-bounds read in the mixed discrete/continuous h-inverse (`hinv2` for `{d, c}`
numeric-inverse families). The public C++ `Bicop` API is unchanged.

> **Note:** pins the **unmerged** vinecopulib#675 branch head — re-pin to the merge SHA once
> vinecopulib#675 merges into vinecopulib `dev`.

### Validation

- `pytest` bicop + vinecop + pickling — 20 passed (new per-row parity / threading / error tests + dependents)
- `ruff` / `ruff format` / `ty` / `clang-format` — clean
- `sphinx -W` — build succeeded