### PR TITLE
Vine scores, Hessians, and per-edge pdf output on `Vinecop`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Use Sphinx autosummary on the four subpackage landing pages so module docstrings, classes, and free functions get their own indexed pages (#214).
 - Add a custom `tree_criterion` for vine structure selection: set `FitControlsVinecop(tree_criterion="custom")` and supply `tree_criterion_function`, a callable `f(data, weights) -> float` mapping a two-column array of pair pseudo-observations (and observation weights) to a scalar edge weight (its absolute value is used). The callable round-trips through pickle when it is picklable (e.g. a module-level function); calls acquire the GIL, so they serialise under `num_threads > 1` ([vinecopulib#674](https://github.com/vinecopulib/vinecopulib/pull/674)).
 - Add per-row-parameter overloads of `Bicop.pdf` / `cdf` / `hfunc1` / `hfunc2` / `hinv1` / `hinv2` / `loglik`: pass an `(n, p)` array of `parameters` (one row per observation, `p` family parameters each) plus an optional `num_threads` to evaluate the copula with a different parameter set per row in a single (optionally threaded) call, instead of reusing the object's stored parameters. Parametric families only ([vinecopulib#675](https://github.com/vinecopulib/vinecopulib/pull/675)).
+- Expose the vine gradient/diagnostics surface on `Vinecop`: `pdf_full` (density plus, with `keep_all=True`, the per-edge densities and h-functions, returned as a dict of `[tree][edge]` nested arrays), `scores` (observation-wise score matrix), `hessian` (per-observation Hessians), `hessian_avg` (average Hessian), and `scores_cov` (score covariance). Mirrors the R additions in [rvinecopulib#320](https://github.com/vinecopulib/rvinecopulib/pull/320).
 
 ### Build / packaging
 
@@ -60,10 +61,12 @@
 - Numpydoc-compliant `//!` comments on every property getter / setter in the Python-binding surface, surfaced through the pyvinecopulib autosummary pages (#214, [vinecopulib#670](https://github.com/vinecopulib/vinecopulib/pull/670)).
 - Allow a custom `tree_criterion` function for vine structure selection ([vinecopulib#674](https://github.com/vinecopulib/vinecopulib/pull/674)).
 - Per-row parameter evaluation for parametric bivariate copulas: `Bicop::pdf` / `cdf` / `hfunc1` / `hfunc2` / `hinv1` / `hinv2` / `loglik` gain an overload taking an `n×p` parameter matrix (one set per observation) plus an optional thread count, backed by an eval-core refactor to a single parameter-aware leaf per family ([vinecopulib#675](https://github.com/vinecopulib/vinecopulib/pull/675)).
+- Improve start parameters when fitting pair copulas on discrete data ([vinecopulib#677](https://github.com/vinecopulib/vinecopulib/pull/677)).
 
 #### BUG FIXES
 
 - Fix an out-of-bounds read in the mixed discrete/continuous h-inverse (`hinv2` for `{d, c}` copulas with a numeric inverse: Frank, BB1/6/7/8, Tawn) ([vinecopulib#675](https://github.com/vinecopulib/vinecopulib/pull/675)).
+- Add a missing thread-related include ([vinecopulib#676](https://github.com/vinecopulib/vinecopulib/pull/676)).
 - Fix `integrade_2d` numerical handling on the bivariate-copula CDF path ([vinecopulib#667](https://github.com/vinecopulib/vinecopulib/pull/667)).
 - Fix a typo in `pdf_d_d` and tighten the threshold under which the analytical derivative is preferred over the finite-difference fallback ([vinecopulib#664](https://github.com/vinecopulib/vinecopulib/pull/664)).
 - Drop an unused fit-controls option ([vinecopulib#662](https://github.com/vinecopulib/vinecopulib/pull/662)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Add a custom `tree_criterion` for vine structure selection: set `FitControlsVinecop(tree_criterion="custom")` and supply `tree_criterion_function`, a callable `f(data, weights) -> float` mapping a two-column array of pair pseudo-observations (and observation weights) to a scalar edge weight (its absolute value is used). The callable round-trips through pickle when it is picklable (e.g. a module-level function); calls acquire the GIL, so they serialise under `num_threads > 1` ([vinecopulib#674](https://github.com/vinecopulib/vinecopulib/pull/674)).
 - Add per-row-parameter overloads of `Bicop.pdf` / `cdf` / `hfunc1` / `hfunc2` / `hinv1` / `hinv2` / `loglik`: pass an `(n, p)` array of `parameters` (one row per observation, `p` family parameters each) plus an optional `num_threads` to evaluate the copula with a different parameter set per row in a single (optionally threaded) call, instead of reusing the object's stored parameters. Parametric families only ([vinecopulib#675](https://github.com/vinecopulib/vinecopulib/pull/675)).
 - Expose the vine gradient/diagnostics surface on `Vinecop`: `pdf_full` (density plus, with `keep_all=True`, the per-edge densities and h-functions, returned as a dict of `[tree][edge]` nested arrays), `scores` (observation-wise score matrix), `hessian` (per-observation Hessians), `hessian_avg` (average Hessian), and `scores_cov` (score covariance). Mirrors the R additions in [rvinecopulib#320](https://github.com/vinecopulib/rvinecopulib/pull/320).
+- Add `RVineStructure.from_struct_array(order, struct_array, natural_order=False, check=True)` (build a structure from an order vector and a `[tree][edge]` nested-list structure array) and `RVineStructure.get_struct_array(natural_order=False)` / `Vinecop.get_struct_array(natural_order=False)` (the full structure array as a nested list, complementing the per-entry `struct_array(tree, edge)`), on top of the `TriangularArray` conversions added in [vinecopulib#680](https://github.com/vinecopulib/vinecopulib/pull/680).
 
 ### Build / packaging
 
@@ -62,6 +63,7 @@
 - Allow a custom `tree_criterion` function for vine structure selection ([vinecopulib#674](https://github.com/vinecopulib/vinecopulib/pull/674)).
 - Per-row parameter evaluation for parametric bivariate copulas: `Bicop::pdf` / `cdf` / `hfunc1` / `hfunc2` / `hinv1` / `hinv2` / `loglik` gain an overload taking an `n×p` parameter matrix (one set per observation) plus an optional thread count, backed by an eval-core refactor to a single parameter-aware leaf per family ([vinecopulib#675](https://github.com/vinecopulib/vinecopulib/pull/675)).
 - Improve start parameters when fitting pair copulas on discrete data ([vinecopulib#677](https://github.com/vinecopulib/vinecopulib/pull/677)).
+- `TriangularArray<T>` owns its conversions: `to_json()`, a JSON constructor, and `to_list()` (nested rows), used by the pyvinecopulib bindings for the structure-array and per-edge outputs ([vinecopulib#680](https://github.com/vinecopulib/vinecopulib/pull/680)).
 
 #### BUG FIXES
 

--- a/scripts/generate_docstring.py
+++ b/scripts/generate_docstring.py
@@ -1284,9 +1284,15 @@ def extract(include_file_map, cursor, symbol_tree, deprecations=None):
       # `choose_doc_var_names` cannot disambiguate and falls back to
       # `doc_was_unable_to_choose_unambiguous_names`. The type-signature
       # check guards against accidentally collapsing legitimate
-      # overloads whose USR happens to collide.
+      # overloads whose USR happens to collide; it compares *canonical*
+      # spellings because a class-nested return type is spelled
+      # differently at the in-class declaration (`Result (...)`) and the
+      # out-of-class definition (`Foo::Result (...)`) — e.g.
+      # `Vinecop::PdfWithHfuncsResult Vinecop::pdf_full(...)`.
       usr = cursor.get_usr() if hasattr(cursor, "get_usr") else None
-      cursor_type = cursor.type.spelling if cursor.type is not None else ""
+      cursor_type = (
+        cursor.type.get_canonical().spelling if cursor.type is not None else ""
+      )
       if usr:
         for j, existing in enumerate(node.doc_symbols):
           existing_usr = (
@@ -1295,7 +1301,7 @@ def extract(include_file_map, cursor, symbol_tree, deprecations=None):
             else None
           )
           existing_type = (
-            existing.cursor.type.spelling
+            existing.cursor.type.get_canonical().spelling
             if existing.cursor.type is not None
             else ""
           )

--- a/src/include/misc/helpers.hpp
+++ b/src/include/misc/helpers.hpp
@@ -18,6 +18,20 @@ inline std::string python_doc_helper(const std::string& module,
   }
 }
 
+// Appends a note to the generated docstring of a method that takes or returns
+// a vinecopulib ``TriangularArray``: the Python binding represents it as a
+// nested list.
+inline std::string struct_array_list_doc(const char* base_doc) {
+  return std::string(base_doc) +
+         R"""(
+
+Notes
+-----
+The triangular array is represented in Python as a nested list indexed
+``[tree][edge]``, where tree ``i`` holds ``d - 1 - i`` entries.
+)""";
+}
+
 // template<typename T>
 // inline std::string
 // python_str_helper(const T& obj, const std::string& label)

--- a/src/include/vinecop/class.hpp
+++ b/src/include/vinecop/class.hpp
@@ -6,6 +6,7 @@
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
 
+#include <algorithm>  // For std::min
 #include <stdexcept>  // For std::invalid_argument
 #include <vinecopulib.hpp>
 
@@ -15,6 +16,28 @@
 namespace nb = nanobind;
 using namespace nb::literals;
 using namespace vinecopulib;
+
+// Convert a vinecopulib ``TriangularArray<T>`` to a nested Python list indexed
+// ``[tree][edge]``. Mirrors ``tools_serialization::triangular_array_to_json``:
+// there are ``min(d - 1, trunc_lvl)`` trees and tree ``i`` has ``d - 1 - i``
+// edges. Each element is cast to Python (an ``Eigen::VectorXd`` becomes a 1-d
+// ndarray; a ``std::vector<Eigen::MatrixXd>`` becomes a list of 2-d ndarrays).
+// Requires the GIL to be held (it builds Python objects).
+template <typename T>
+inline nb::list triangular_to_list(const TriangularArray<T>& array) {
+  const size_t d = array.get_dim();
+  const size_t trunc_lvl = array.get_trunc_lvl();
+  nb::list trees;
+  const size_t n_trees = (d >= 1) ? std::min(d - 1, trunc_lvl) : 0;
+  for (size_t i = 0; i < n_trees; ++i) {
+    nb::list edges;
+    for (size_t j = 0; j + 1 + i < d; ++j) {  // j < d - 1 - i, underflow-safe
+      edges.append(nb::cast(array(i, j)));
+    }
+    trees.append(edges);
+  }
+  return trees;
+}
 
 inline void vinecop_plot_wrapper(const Vinecop& cop, nb::object tree,
                                  bool add_edge_labels,
@@ -125,6 +148,34 @@ are:
       Fit controls for the vinecop. Defaults to the default constructor.
   )""";
 
+  // Supplied inline rather than via the generated docstring: the C++ facade
+  // returns a ``PdfWithHfuncsResult`` struct (whose inline definition trips up
+  // the libclang docstring extractor), whereas the Python method returns a
+  // dict. This documents the actual Python return.
+  const char* pdf_full_doc =
+      R"""(Evaluates the vine copula density and, optionally, the per-edge densities and h-functions.
+
+Parameters
+----------
+u : ndarray, shape (n, d) or (n, 2 * d), dtype float
+    Evaluation points in (0, 1); additional columns are required for discrete
+    variables (see ``Vinecop.select``).
+num_threads : int, default 1
+    Number of threads to parallelize the row-wise evaluation over.
+keep_all : bool, default True
+    If True, also return the per-edge densities and h-functions.
+
+Returns
+-------
+dict
+    A dict with key ``"pdf"`` (an ndarray of length n, the copula density). If
+    ``keep_all`` is True, it also contains ``"pdf_edges"``, ``"hfunc1"``,
+    ``"hfunc2"``, ``"hfunc1_sub"`` and ``"hfunc2_sub"``, each a nested list
+    indexed ``[tree][edge]`` of length-n arrays. The ``_sub`` fields hold the
+    left-limit h-functions and are only populated when at least one variable is
+    discrete.
+)""";
+
   const char* from_structure_doc = R"""(
   Factory function to create a Vinecop using either a structure or a matrix.
 
@@ -234,6 +285,29 @@ are:
            nb::call_guard<nb::gil_scoped_release>())
       .def("pdf", &Vinecop::pdf, "u"_a, "num_threads"_a = 1,
            vinecop_doc.pdf.doc, nb::call_guard<nb::gil_scoped_release>())
+      .def(
+          "pdf_full",
+          [](const Vinecop& cop, Eigen::MatrixXd u, size_t num_threads,
+             bool keep_all) -> nb::dict {
+            Vinecop::PdfWithHfuncsResult res;
+            {
+              // Release the GIL only around the C++ computation; the dict /
+              // list construction below must hold it.
+              nb::gil_scoped_release release;
+              res = cop.pdf_full(std::move(u), num_threads, keep_all);
+            }
+            nb::dict out;
+            out["pdf"] = nb::cast(res.pdf);
+            if (keep_all) {
+              out["pdf_edges"] = triangular_to_list(res.pdf_edges);
+              out["hfunc1"] = triangular_to_list(res.hfunc1);
+              out["hfunc2"] = triangular_to_list(res.hfunc2);
+              out["hfunc1_sub"] = triangular_to_list(res.hfunc1_sub);
+              out["hfunc2_sub"] = triangular_to_list(res.hfunc2_sub);
+            }
+            return out;
+          },
+          "u"_a, "num_threads"_a = 1, "keep_all"_a = true, pdf_full_doc)
       .def("cdf", &Vinecop::cdf, "u"_a, "N"_a = 10000, "num_threads"_a = 1,
            "seeds"_a = std::vector<int>(), vinecop_doc.cdf.doc,
            nb::call_guard<nb::gil_scoped_release>())
@@ -256,6 +330,30 @@ are:
       .def("mbicv", &Vinecop::mbicv, "u"_a = Eigen::MatrixXd(), "psi0"_a = 0.9,
            "num_threads"_a = 1, vinecop_doc.mbicv.doc,
            nb::call_guard<nb::gil_scoped_release>())
+      .def("scores", &Vinecop::scores, "u"_a, "step_wise"_a = true,
+           "num_threads"_a = 1, vinecop_doc.scores.doc,
+           nb::call_guard<nb::gil_scoped_release>())
+      .def("hessian_avg", &Vinecop::hessian_avg, "u"_a, "step_wise"_a = true,
+           "num_threads"_a = 1, vinecop_doc.hessian_avg.doc,
+           nb::call_guard<nb::gil_scoped_release>())
+      .def("scores_cov", &Vinecop::scores_cov, "u"_a, "step_wise"_a = true,
+           "num_threads"_a = 1, vinecop_doc.scores_cov.doc,
+           nb::call_guard<nb::gil_scoped_release>())
+      .def(
+          "hessian",
+          [](Vinecop& cop, Eigen::MatrixXd u, bool step_wise,
+             size_t num_threads) -> nb::list {
+            TriangularArray<std::vector<Eigen::MatrixXd>> hess;
+            {
+              // Release the GIL only around the C++ computation; the nested
+              // list construction below must hold it.
+              nb::gil_scoped_release release;
+              hess = cop.hessian(std::move(u), step_wise, num_threads);
+            }
+            return triangular_to_list(hess);
+          },
+          "u"_a, "step_wise"_a = true, "num_threads"_a = 1,
+          vinecop_doc.hessian.doc)
       .def(
           "__repr__",
           [](const Vinecop& cop) {

--- a/src/include/vinecop/class.hpp
+++ b/src/include/vinecop/class.hpp
@@ -18,25 +18,13 @@ using namespace nb::literals;
 using namespace vinecopulib;
 
 // Convert a vinecopulib ``TriangularArray<T>`` to a nested Python list indexed
-// ``[tree][edge]``. Mirrors ``tools_serialization::triangular_array_to_json``:
-// there are ``min(d - 1, trunc_lvl)`` trees and tree ``i`` has ``d - 1 - i``
-// edges. Each element is cast to Python (an ``Eigen::VectorXd`` becomes a 1-d
-// ndarray; a ``std::vector<Eigen::MatrixXd>`` becomes a list of 2-d ndarrays).
-// Requires the GIL to be held (it builds Python objects).
+// ``[tree][edge]`` via ``TriangularArray::to_list()``. An ``Eigen::VectorXd``
+// element becomes a 1-d ndarray; a ``std::vector<Eigen::MatrixXd>`` element
+// becomes a list of 2-d ndarrays. Requires the GIL to be held (it builds
+// Python objects).
 template <typename T>
 inline nb::list triangular_to_list(const TriangularArray<T>& array) {
-  const size_t d = array.get_dim();
-  const size_t trunc_lvl = array.get_trunc_lvl();
-  nb::list trees;
-  const size_t n_trees = (d >= 1) ? std::min(d - 1, trunc_lvl) : 0;
-  for (size_t i = 0; i < n_trees; ++i) {
-    nb::list edges;
-    for (size_t j = 0; j + 1 + i < d; ++j) {  // j < d - 1 - i, underflow-safe
-      edges.append(nb::cast(array(i, j)));
-    }
-    trees.append(edges);
-  }
-  return trees;
+  return nb::steal<nb::list>(nb::cast(array.to_list()).release());
 }
 
 inline void vinecop_plot_wrapper(const Vinecop& cop, nb::object tree,
@@ -273,6 +261,13 @@ dict
       .def_prop_ro("npars", &Vinecop::get_npars, vinecop_doc.get_npars.doc)
       .def_prop_ro("matrix", &Vinecop::get_matrix, vinecop_doc.get_matrix.doc,
                    nb::call_guard<nb::gil_scoped_release>())
+      .def(
+          "get_struct_array",
+          [](const Vinecop& cop, bool natural_order) -> nb::list {
+            return triangular_to_list(cop.get_struct_array(natural_order));
+          },
+          "natural_order"_a = false,
+          struct_array_list_doc(vinecop_doc.get_struct_array.doc).c_str())
       .def_prop_ro("nobs", &Vinecop::get_nobs, vinecop_doc.get_nobs.doc)
       .def_prop_ro("threshold", &Vinecop::get_threshold,
                    vinecop_doc.get_threshold.doc)

--- a/src/include/vinecop/rvine_structure.hpp
+++ b/src/include/vinecop/rvine_structure.hpp
@@ -9,6 +9,7 @@
 #include <vinecopulib.hpp>
 
 #include "docstr.hpp"
+#include "misc/helpers.hpp"
 
 namespace nb = nanobind;
 using namespace nb::literals;
@@ -33,6 +34,16 @@ inline RVineStructure rv_from_order(
     const std::vector<size_t>& order,
     size_t trunc_lvl = std::numeric_limits<size_t>::max(), bool check = true) {
   return RVineStructure(order, trunc_lvl, check);
+}
+
+// Factory function to create RVineStructure from an order vector and a
+// structure array given as nested rows (tree i holds d - 1 - i entries)
+inline RVineStructure rv_from_struct_array(
+    const std::vector<size_t>& order,
+    const std::vector<std::vector<size_t>>& struct_array,
+    bool natural_order = false, bool check = true) {
+  return RVineStructure(order, TriangularArray<size_t>(struct_array),
+                        natural_order, check);
 }
 
 // Factory function to create RVineStructure from a file
@@ -62,6 +73,7 @@ Alternatives to instantiate structures are:
 
 - ``RVineStructure.from_order()``: Instantiate from an order vector.
 - ``RVineStructure.from_matrix()``: Instantiate from a matrix.
+- ``RVineStructure.from_struct_array()``: Instantiate from an order vector and a structure array.
 - ``RVineStructure.from_file()``: Instantiate from a file.
 - ``RVineStructure.from_json()``: Instantiate from a JSON string.
 )""";
@@ -83,6 +95,13 @@ Alternatives to instantiate structures are:
                   "trunc_lvl"_a = std::numeric_limits<size_t>::max(),
                   "check"_a = true,
                   rvinestructure_doc.ctor.doc_3args_order_trunc_lvl_check,
+                  nb::call_guard<nb::gil_scoped_release>())
+      .def_static("from_struct_array", &rv_from_struct_array, "order"_a,
+                  "struct_array"_a, "natural_order"_a = false, "check"_a = true,
+                  struct_array_list_doc(
+                      rvinestructure_doc.ctor
+                          .doc_4args_order_struct_array_natural_order_check)
+                      .c_str(),
                   nb::call_guard<nb::gil_scoped_release>())
       .def_static("from_file", &rv_from_file, "filename"_a, "check"_a = true,
                   rvinestructure_doc.ctor.doc_2args_filename_check,
@@ -113,6 +132,14 @@ Alternatives to instantiate structures are:
       .def("struct_array", &RVineStructure::struct_array, "tree"_a, "edge"_a,
            "natural_order"_a = false, rvinestructure_doc.struct_array.doc,
            nb::call_guard<nb::gil_scoped_release>())
+      .def(
+          "get_struct_array",
+          [](const RVineStructure& rvs, bool natural_order) -> nb::list {
+            return triangular_to_list(rvs.get_struct_array(natural_order));
+          },
+          "natural_order"_a = false,
+          struct_array_list_doc(rvinestructure_doc.get_struct_array.doc)
+              .c_str())
       .def("min_array", &RVineStructure::min_array, "tree"_a, "edge"_a,
            rvinestructure_doc.min_array.doc,
            nb::call_guard<nb::gil_scoped_release>())

--- a/tests/test_vinecop.py
+++ b/tests/test_vinecop.py
@@ -291,3 +291,38 @@ def test_vinecop_scores_and_hessian() -> None:
       assert isinstance(mat, np.ndarray) and mat.ndim == 2
 
   _check_triangular(cop.hessian(u), d, _is_matrix_list)
+
+
+def test_struct_array_accessors_and_factory() -> None:
+  d, n = 5, 200
+  u = pv.to_pseudo_obs(random_data(d, n))
+  cop = pv.Vinecop.from_data(
+    u, controls=pv.FitControlsVinecop(family_set=[pv.families.gaussian])
+  )
+  structure = cop.structure
+
+  for natural_order in (False, True):
+    # get_struct_array returns a [tree][edge] nested list matching the
+    # per-entry accessor.
+    arr = structure.get_struct_array(natural_order=natural_order)
+    assert isinstance(arr, list) and len(arr) == d - 1
+    for t, tree in enumerate(arr):
+      assert isinstance(tree, list)
+      assert len(tree) == d - 1 - t
+      for e, entry in enumerate(tree):
+        assert entry == structure.struct_array(
+          t, e, natural_order=natural_order
+        )
+
+    # The vine's convenience accessor matches its structure's.
+    assert cop.get_struct_array(natural_order=natural_order) == arr
+
+    # from_struct_array(order, struct_array) rebuilds the same structure.
+    rebuilt = pv.RVineStructure.from_struct_array(
+      structure.order, arr, natural_order=natural_order
+    )
+    assert np.array_equal(rebuilt.matrix, structure.matrix)
+
+  # Rows that do not form a triangular array are rejected.
+  with pytest.raises(RuntimeError):
+    pv.RVineStructure.from_struct_array(structure.order, [[1, 2], [3, 4]])

--- a/tests/test_vinecop.py
+++ b/tests/test_vinecop.py
@@ -198,3 +198,96 @@ def test_custom_criterion_multithread_smoke() -> None:
   cop2 = pv.Vinecop.from_data(u, controls=c2)
 
   assert np.array_equal(cop1.matrix, cop2.matrix)
+
+
+def _check_triangular(arr: object, d: int, leaf_check) -> None:
+  """Validate a ``[tree][edge]`` nested list: tree ``i`` has ``d - 1 - i``
+  entries, each passing ``leaf_check``. isinstance narrowing at every level
+  keeps the (untyped) dict/list contents type-checkable."""
+  assert isinstance(arr, list)
+  for i, tree in enumerate(arr):
+    assert isinstance(tree, list)
+    assert len(tree) == d - 1 - i
+    for leaf in tree:
+      leaf_check(leaf)
+
+
+def test_vinecop_pdf_full() -> None:
+  d, n = 4, 200
+  u = pv.to_pseudo_obs(random_data(d, n))
+  cop = pv.Vinecop.from_data(
+    u, controls=pv.FitControlsVinecop(family_set=[pv.families.gaussian])
+  )
+
+  # keep_all=True (default): dict with the density + per-edge triangular arrays.
+  full = cop.pdf_full(u)
+  assert isinstance(full, dict)
+  assert set(full) == {
+    "pdf",
+    "pdf_edges",
+    "hfunc1",
+    "hfunc2",
+    "hfunc1_sub",
+    "hfunc2_sub",
+  }
+  assert isinstance(full["pdf"], np.ndarray) and full["pdf"].shape == (n,)
+  np.testing.assert_allclose(full["pdf"], cop.pdf(u), rtol=1e-10, atol=1e-12)
+
+  # Triangular arrays are nested lists [tree][edge], with d - 1 edges in tree 0
+  # and one fewer per subsequent tree. Per-edge densities are always length n;
+  # h-functions are only filled where the cascade needs them (unneeded edges are
+  # returned empty).
+  def _is_len_n_vector(vec: object) -> None:
+    assert isinstance(vec, np.ndarray) and vec.shape == (n,)
+
+  def _is_edge_vector(vec: object) -> None:
+    assert isinstance(vec, np.ndarray) and vec.shape in ((n,), (0,))
+
+  _check_triangular(full["pdf_edges"], d, _is_len_n_vector)
+  for key in ("hfunc1", "hfunc2", "hfunc1_sub", "hfunc2_sub"):
+    _check_triangular(full[key], d, _is_edge_vector)
+
+  # keep_all=False: only the density.
+  simple = cop.pdf_full(u, keep_all=False)
+  assert set(simple) == {"pdf"}
+  np.testing.assert_allclose(simple["pdf"], cop.pdf(u), rtol=1e-10, atol=1e-12)
+
+  # num_threads must not change the result.
+  np.testing.assert_allclose(
+    cop.pdf_full(u, num_threads=2)["pdf"], full["pdf"], rtol=1e-12, atol=1e-14
+  )
+
+
+def test_vinecop_scores_and_hessian() -> None:
+  d, n = 4, 200
+  u = pv.to_pseudo_obs(random_data(d, n))
+  cop = pv.Vinecop.from_data(
+    u, controls=pv.FitControlsVinecop(family_set=[pv.families.gaussian])
+  )
+
+  # scores: one row per observation, one column per parameter.
+  scores = cop.scores(u)
+  assert isinstance(scores, np.ndarray) and scores.ndim == 2
+  assert scores.shape[0] == n
+  p = scores.shape[1]
+  assert p == round(cop.npars)
+
+  # scores_cov / hessian_avg: (p, p) matrices; scores_cov is symmetric.
+  cov = cop.scores_cov(u)
+  assert cov.shape == (p, p)
+  np.testing.assert_allclose(cov, cov.T, rtol=1e-10, atol=1e-12)
+  assert cop.hessian_avg(u).shape == (p, p)
+
+  # step_wise=False and threading run and are consistent.
+  assert cop.scores(u, step_wise=False).shape == (n, p)
+  np.testing.assert_allclose(
+    cop.scores(u, num_threads=2), scores, rtol=1e-10, atol=1e-12
+  )
+
+  # Per-observation hessian: nested lists [tree][edge], each a list of matrices.
+  def _is_matrix_list(leaf: object) -> None:
+    assert isinstance(leaf, list)
+    for mat in leaf:
+      assert isinstance(mat, np.ndarray) and mat.ndim == 2
+
+  _check_triangular(cop.hessian(u), d, _is_matrix_list)


### PR DESCRIPTION
## Vine scores, Hessians, per-edge pdf output, and struct-array plumbing on `Vinecop` / `RVineStructure`

Exposes the diagnostics/gradient surface added upstream (mirroring the R additions in [rvinecopulib#320](https://github.com/vinecopulib/rvinecopulib/pull/320)), plus structure-array conversions built on new upstream `TriangularArray` methods.

### Vine diagnostics (first commit)

- **`pdf_full(u, num_threads=1, keep_all=True)`** — the vine density plus, when `keep_all=True`, the per-edge densities and h-functions. Returns a **dict** with keys `pdf`, `pdf_edges`, `hfunc1`, `hfunc2`, `hfunc1_sub`, `hfunc2_sub`; each non-`pdf` value is a nested list indexed `[tree][edge]` of length-`n` arrays (h-function edges the cascade doesn't need are returned empty; `_sub` holds left-limit h-functions for discrete variables). The existing `pdf(u, num_threads=1) -> ndarray` is unchanged.
- **`scores(u, step_wise=True, num_threads=1)`** — observation-wise score matrix `(n, npars)`.
- **`hessian(u, step_wise=True, num_threads=1)`** — per-observation Hessians as a `[tree][edge]` nested list of matrices.
- **`hessian_avg(...)`** / **`scores_cov(...)`** — average Hessian and score covariance, `(npars, npars)`.

### Struct-array plumbing (second commit)

- **`RVineStructure.from_struct_array(order, struct_array, natural_order=False, check=True)`** — build a structure from an order vector and a `[tree][edge]` nested-list structure array (the Pythonic face of the C++ `RVineStructure(order, struct_array, ...)` constructor).
- **`RVineStructure.get_struct_array(natural_order=False)`** and **`Vinecop.get_struct_array(natural_order=False)`** — the full structure array as a nested list, complementing the per-entry `struct_array(tree, edge)`.
- The `pdf_full` / `hessian` bindings now convert triangular arrays via the new upstream `TriangularArray::to_list()` instead of a hand-rolled loop.
- **Docstring-extractor fix** (`scripts/generate_docstring.py`): clang associates a doc comment with both the declaration and the out-of-class definition; for methods returning a *class-nested* type (e.g. `Vinecop::PdfWithHfuncsResult pdf_full(...)`) the two cursors' type spellings differ (`Result (...)` vs `Foo::Result (...)`), defeating the same-USR dedup and producing a `doc_was_unable_to_choose_unambiguous_names` fallback symbol. The dedup now compares **canonical** type spellings; the regenerated `docstr.hpp` diff is limited to exactly that symbol.

### Submodule

Pins `lib/vinecopulib` to the `feat/triangular-array-methods` head (`cab6d06`, on top of vinecopulib `dev` = merged #675 + #676 + #677), which adds `TriangularArray::to_json()` / JSON constructor / `to_list()` and removes the internal `tools_serialization` triangular-array helpers (vinecopulib#680).

> **Note:** re-pin to the vinecopulib `dev` merge SHA once the upstream PR merges.

### Validation

- `pytest tests/test_vinecop.py tests/test_bicop.py tests/test_pickling.py` — 23 passed (per-row/pdf_full/scores/Hessian tests + new struct-array round-trips + dependents).
- `ruff check` / `ruff format --check` / `ty check` / `clang-format` — clean; generated stubs fully typed (`from_struct_array(order: Sequence[int], struct_array: Sequence[Sequence[int]], ...)`).
- `sphinx-build -W` — build succeeded.
- Upstream: `rvine_structure` suite (incl. new conversion round-trips) passes in Debug; clang-format-14 clean.
