### PR TITLE
feat(core): bump lib/vinecopulib to 0.8.0 dev head; rename Vinecop Hessian API (vinecopulib#679)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
 # Changelog
 
-## 1.0.0
+## 0.8.0
 
 ### Breaking API changes in `pyvinecopulib`
 
 - Reorganize the public API into the `core` / `families` / `utils` / `sklearn` subpackages (#207).
     - Top-level classes (`Bicop`, `Vinecop`, `RVineStructure`, `CVineStructure`, `DVineStructure`, `FitControlsBicop`, `FitControlsVinecop`, `BicopFamily`) and `to_pseudo_obs` are kept at the top level indefinitely.
-    - Family constants / groups (`indep`, `gaussian`, …, `parametric`, …, `itau`), `Kde1d`, `wdm`, `sobol`, `ghalton`, `simulate_uniform`, `benchmark`, `pairs_copula_data` still resolve at the top level but emit a `DeprecationWarning` on access pointing at the canonical subpackage path. Aliases are scheduled for removal in 2.0.
-    - `repr` and pickle now use canonical module paths (`Bicop.__module__ == "pyvinecopulib.core"`, `Kde1d.__module__ == "pyvinecopulib.utils"`, etc.); pre-1.0 pickles still load via the deprecated aliases.
+    - Family constants / groups (`indep`, `gaussian`, …, `parametric`, …, `itau`), `Kde1d`, `wdm`, `sobol`, `ghalton`, `simulate_uniform`, `benchmark`, `pairs_copula_data` still resolve at the top level but emit a `DeprecationWarning` on access pointing at the canonical subpackage path. Aliases are scheduled for removal in the next major release.
+    - `repr` and pickle now use canonical module paths (`Bicop.__module__ == "pyvinecopulib.core"`, `Kde1d.__module__ == "pyvinecopulib.utils"`, etc.); pickles from releases up to 0.7.x still load via the deprecated aliases.
 - `pyvinecopulib.sklearn` estimators take a single `backend=` keyword (#218).
     - `VineDensity(controls=..., structure=..., seed=...)` → `VineDensity(backend=VinecopBackend(controls=..., structure=...), random_state=...)`. Same shape change for `VineRegressor` / `VineForestDensity` / `VineForestRegressor`. No string shortcuts; pass a `VinecopBackend` or `TorchVinecopBackend` instance.
     - `seed`-style kwargs renamed to `random_state` across the forests and on `VineDensity.sample` / `VineDensity.cdf` / `VineForestDensity.cdf`. Legacy `seed` / `seeds` kwargs removed without a deprecation alias.
@@ -27,7 +27,7 @@
 - Use Sphinx autosummary on the four subpackage landing pages so module docstrings, classes, and free functions get their own indexed pages (#214).
 - Add a custom `tree_criterion` for vine structure selection: set `FitControlsVinecop(tree_criterion="custom")` and supply `tree_criterion_function`, a callable `f(data, weights) -> float` mapping a two-column array of pair pseudo-observations (and observation weights) to a scalar edge weight (its absolute value is used). The callable round-trips through pickle when it is picklable (e.g. a module-level function); calls acquire the GIL, so they serialise under `num_threads > 1` ([vinecopulib#674](https://github.com/vinecopulib/vinecopulib/pull/674)).
 - Add per-row-parameter overloads of `Bicop.pdf` / `cdf` / `hfunc1` / `hfunc2` / `hinv1` / `hinv2` / `loglik`: pass an `(n, p)` array of `parameters` (one row per observation, `p` family parameters each) plus an optional `num_threads` to evaluate the copula with a different parameter set per row in a single (optionally threaded) call, instead of reusing the object's stored parameters. Parametric families only ([vinecopulib#675](https://github.com/vinecopulib/vinecopulib/pull/675)).
-- Expose the vine gradient/diagnostics surface on `Vinecop`: `pdf_full` (density plus, with `keep_all=True`, the per-edge densities and h-functions, returned as a dict of `[tree][edge]` nested arrays), `scores` (observation-wise score matrix), `hessian` (per-observation Hessians), `hessian_avg` (average Hessian), and `scores_cov` (score covariance). Mirrors the R additions in [rvinecopulib#320](https://github.com/vinecopulib/rvinecopulib/pull/320).
+- Expose the vine gradient/diagnostics surface on `Vinecop`: `pdf_full` (density plus, with `keep_all=True`, the per-edge densities and h-functions, returned as a dict of `[tree][edge]` nested arrays; the left-limit `hfunc*_sub` entries are only populated for models with discrete variables), `scores` (observation-wise score matrix), `hessian` (average Hessian), `hessian_full` (per-observation Hessians), and `scores_cov` (score covariance). Scores and Hessians are computed analytically (models with discrete variables fall back to finite differences); models with nonparametric pair copulas raise `RuntimeError`. Mirrors the R additions in [rvinecopulib#320](https://github.com/vinecopulib/rvinecopulib/pull/320) ([vinecopulib#679](https://github.com/vinecopulib/vinecopulib/pull/679), [vinecopulib#683](https://github.com/vinecopulib/vinecopulib/pull/683)).
 - Add `RVineStructure.from_struct_array(order, struct_array, natural_order=False, check=True)` (build a structure from an order vector and a `[tree][edge]` nested-list structure array) and `RVineStructure.get_struct_array(natural_order=False)` / `Vinecop.get_struct_array(natural_order=False)` (the full structure array as a nested list, complementing the per-entry `struct_array(tree, edge)`), on top of the `TriangularArray` conversions added in [vinecopulib#680](https://github.com/vinecopulib/vinecopulib/pull/680).
 
 ### Build / packaging
@@ -64,6 +64,17 @@
 - Per-row parameter evaluation for parametric bivariate copulas: `Bicop::pdf` / `cdf` / `hfunc1` / `hfunc2` / `hinv1` / `hinv2` / `loglik` gain an overload taking an `n×p` parameter matrix (one set per observation) plus an optional thread count, backed by an eval-core refactor to a single parameter-aware leaf per family ([vinecopulib#675](https://github.com/vinecopulib/vinecopulib/pull/675)).
 - Improve start parameters when fitting pair copulas on discrete data ([vinecopulib#677](https://github.com/vinecopulib/vinecopulib/pull/677)).
 - `TriangularArray<T>` owns its conversions: `to_json()`, a JSON constructor, and `to_list()` (nested rows), used by the pyvinecopulib bindings for the structure-array and per-edge outputs ([vinecopulib#680](https://github.com/vinecopulib/vinecopulib/pull/680)).
+- Analytic derivatives of the bivariate copula density and h-functions with respect to parameters and arguments for all parametric families, making `Vinecop` scores and Hessians analytic (exact and faster); models with nonparametric pair copulas are now rejected by `scores` / `hessian` ([vinecopulib#683](https://github.com/vinecopulib/vinecopulib/pull/683), [vinecopulib#687](https://github.com/vinecopulib/vinecopulib/pull/687)). The TLL family additionally gains the exact argument gradient of its density ([vinecopulib#694](https://github.com/vinecopulib/vinecopulib/pull/694)).
+- Rename the `Vinecop` Hessian API: `hessian_avg` → `hessian` (average) and `hessian` → `hessian_full` (per-observation), mirrored by the Python bindings ([vinecopulib#679](https://github.com/vinecopulib/vinecopulib/pull/679)).
+
+#### PERFORMANCE
+
+- Speed up the bicop evaluation engine: vectorized closed-form pdf / h-function / CDF leaves and derivative-cascade allocation hygiene. Evaluations may shift by ≤ 1e-12 and fitted parameters by ≤ 1e-8 ([vinecopulib#681](https://github.com/vinecopulib/vinecopulib/pull/681)).
+- Speed up `Vinecop` evaluation and structure selection: no per-edge copula copies in `inverse_rosenblatt`, in-place data collapsing, parallel allocation-free Monte-Carlo `cdf`, and selection fast paths. `pdf_full` no longer duplicates continuous h-functions into the `hfunc*_sub` buffers (they are now empty for models without discrete variables) ([vinecopulib#692](https://github.com/vinecopulib/vinecopulib/pull/692)).
+- Speed up TLL fitting and evaluation: fused conditional-cdf interpolation and closed-form inversion of the conditional cdf. TLL `hinv1` / `hinv2` (hence `simulate` / `inverse_rosenblatt` on TLL vines) may shift by ≤ 1e-9 ([vinecopulib#691](https://github.com/vinecopulib/vinecopulib/pull/691)).
+- Speed up `tools_stats`: SIMD `qnorm`, leaner bivariate normal / t kernels, faster pseudo-observations and quasi-random fills. Gaussian / Student evaluations may shift at the ≤ 1e-12 level ([vinecopulib#690](https://github.com/vinecopulib/vinecopulib/pull/690)).
+- Faster shared Eigen / thread / integration primitives; the relaxed integration tolerance (1e-12 → 1e-9) may shift Kendall's τ of the integrated families (BB6 / BB7 / BB8, Tawn) by up to ~1e-7 ([vinecopulib#689](https://github.com/vinecopulib/vinecopulib/pull/689)).
+- Compute the Student t score's df-only terms once per call, speeding up `Vinecop` scores / Hessians and Student t maximum-likelihood fits ([vinecopulib#693](https://github.com/vinecopulib/vinecopulib/pull/693)).
 
 #### BUG FIXES
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "pyvinecopulib"
-version = "1.0.0"
+version = "0.8.0"
 authors = [
   { name = "Thibault Vatter", email = "info@vinecopulib.com" },
   { name = "Thomas Nagler", email = "info@vinecopulib.com" },

--- a/src/include/vinecop/class.hpp
+++ b/src/include/vinecop/class.hpp
@@ -161,7 +161,7 @@ dict
     ``"hfunc2"``, ``"hfunc1_sub"`` and ``"hfunc2_sub"``, each a nested list
     indexed ``[tree][edge]`` of length-n arrays. The ``_sub`` fields hold the
     left-limit h-functions and are only populated when at least one variable is
-    discrete.
+    discrete; for models without discrete variables they are empty lists.
 )""";
 
   const char* from_structure_doc = R"""(
@@ -328,14 +328,14 @@ dict
       .def("scores", &Vinecop::scores, "u"_a, "step_wise"_a = true,
            "num_threads"_a = 1, vinecop_doc.scores.doc,
            nb::call_guard<nb::gil_scoped_release>())
-      .def("hessian_avg", &Vinecop::hessian_avg, "u"_a, "step_wise"_a = true,
-           "num_threads"_a = 1, vinecop_doc.hessian_avg.doc,
+      .def("hessian", &Vinecop::hessian, "u"_a, "step_wise"_a = true,
+           "num_threads"_a = 1, vinecop_doc.hessian.doc,
            nb::call_guard<nb::gil_scoped_release>())
       .def("scores_cov", &Vinecop::scores_cov, "u"_a, "step_wise"_a = true,
            "num_threads"_a = 1, vinecop_doc.scores_cov.doc,
            nb::call_guard<nb::gil_scoped_release>())
       .def(
-          "hessian",
+          "hessian_full",
           [](Vinecop& cop, Eigen::MatrixXd u, bool step_wise,
              size_t num_threads) -> nb::list {
             TriangularArray<std::vector<Eigen::MatrixXd>> hess;
@@ -343,12 +343,12 @@ dict
               // Release the GIL only around the C++ computation; the nested
               // list construction below must hold it.
               nb::gil_scoped_release release;
-              hess = cop.hessian(std::move(u), step_wise, num_threads);
+              hess = cop.hessian_full(std::move(u), step_wise, num_threads);
             }
             return triangular_to_list(hess);
           },
           "u"_a, "step_wise"_a = true, "num_threads"_a = 1,
-          vinecop_doc.hessian.doc)
+          vinecop_doc.hessian_full.doc)
       .def(
           "__repr__",
           [](const Vinecop& cop) {

--- a/tests/test_vinecop.py
+++ b/tests/test_vinecop.py
@@ -244,8 +244,14 @@ def test_vinecop_pdf_full() -> None:
     assert isinstance(vec, np.ndarray) and vec.shape in ((n,), (0,))
 
   _check_triangular(full["pdf_edges"], d, _is_len_n_vector)
-  for key in ("hfunc1", "hfunc2", "hfunc1_sub", "hfunc2_sub"):
+  for key in ("hfunc1", "hfunc2"):
     _check_triangular(full[key], d, _is_edge_vector)
+
+  # The left-limit h-functions are only computed for models with discrete
+  # variables; for an all-continuous model they come back empty
+  # (vinecopulib#692).
+  assert full["hfunc1_sub"] == []
+  assert full["hfunc2_sub"] == []
 
   # keep_all=False: only the density.
   simple = cop.pdf_full(u, keep_all=False)
@@ -272,11 +278,11 @@ def test_vinecop_scores_and_hessian() -> None:
   p = scores.shape[1]
   assert p == round(cop.npars)
 
-  # scores_cov / hessian_avg: (p, p) matrices; scores_cov is symmetric.
+  # scores_cov / hessian: (p, p) matrices; scores_cov is symmetric.
   cov = cop.scores_cov(u)
   assert cov.shape == (p, p)
   np.testing.assert_allclose(cov, cov.T, rtol=1e-10, atol=1e-12)
-  assert cop.hessian_avg(u).shape == (p, p)
+  assert cop.hessian(u).shape == (p, p)
 
   # step_wise=False and threading run and are consistent.
   assert cop.scores(u, step_wise=False).shape == (n, p)
@@ -290,7 +296,7 @@ def test_vinecop_scores_and_hessian() -> None:
     for mat in leaf:
       assert isinstance(mat, np.ndarray) and mat.ndim == 2
 
-  _check_triangular(cop.hessian(u), d, _is_matrix_list)
+  _check_triangular(cop.hessian_full(u), d, _is_matrix_list)
 
 
 def test_struct_array_accessors_and_factory() -> None:


### PR DESCRIPTION
First PR of the vinecopulib 0.8.0 integration stack. Bumps `lib/vinecopulib` from `cab6d06` (vinecopulib#680 head) to the current dev head `8b7d78e` (vinecopulib#681 merge) and contains everything required to keep the suite green; the new binding surfaces follow as separate PRs on top:

1. **this PR** — bump + Hessian rename + drift absorption + 0.8.0 version alignment
2. `Bicop.taildep` / `Bicop.beta` (vinecopulib#682)
3. `Bicop.*_deriv{,2}` + `families.analytic_derivs` (vinecopulib#683/#687/#694)
4. `Vinecop.gradient` + `Vinecop.scores_full` (vinecopulib#683)
5. CBOR polish (vinecopulib#684)
6. torch: closed-form TLL h-inverse port + benchmark (parity with vinecopulib#691)

## What's in the bump

vinecopulib#679, #681–#684, #686–#694 (see the updated `CHANGELOG.md` for the itemized list with drift notes).

## Changes here

- **Rename** (vinecopulib#679): `Vinecop.hessian_avg` → `Vinecop.hessian` (average, direct member binding) and `Vinecop.hessian` → `Vinecop.hessian_full` (per-observation ragged). No deprecation alias — neither name was ever released (added in unreleased #228).
- **Behavior absorbed**: `scores`/`hessian` are analytic upstream and now raise `RuntimeError` for models with nonparametric pair copulas (vinecopulib#683); `pdf_full`'s `hfunc*_sub` entries are empty lists for models without discrete variables (vinecopulib#692) — docstring + test pin the new contract.
- **Version alignment**: the release will be **0.8.0** (matching vinecopulib 0.8.0), not 1.0.0 — `pyproject.toml`, CHANGELOG heading, and version-relative wording updated.
- **CHANGELOG**: upstream `PERFORMANCE` section with user-visible drift bounds (BB/Tawn τ ≤1e-7, TLL hinv ≤1e-9, Gaussian/Student ≤1e-12, fitted parameters ≤1e-8).

## Validation

- `make sync` / `make check` / `make test`: **449 passed, 69 xfailed** — no existing tolerance tripped by the upstream numeric drift (the planned torch↔C++ TLL parity loosening turned out unnecessary).
- `make docs` (`sphinx -W`) clean after clearing stale `docs/_generate` artifacts.

## Follow-up (release checklist)

- Re-bump once vinecopulib#685 (BOBYQA → Brent+BFGS) merges — bump-only, audit fitted-parameter assertions for multi-parameter mle fits.
- Re-pin to the final vinecopulib 0.8.0 tag/merge SHA before tagging the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)