### PR TITLE
fix(build): resolve EIGEN3_INCLUDE_DIR from Eigen3::Eigen target (Eigen 5.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 - Fix osx / musllinux wheel builds: feed libclang the compiler's implicit system include dirs (plus `-ferror-limit=0` and the macOS SDK sysroot) so the C++ stdlib / intrinsic headers resolve, and abort `docstr.hpp` generation only on *fatal* libclang diagnostics (intrinsic-header `error`s are benign and no longer silently drop symbols).
 - Fix Windows wheel builds against the VS 2026 / MSVC 14.51 STL: rewrite `__builtin_verbose_trap` to `__builtin_trap()` during `docstr.hpp` generation. The newer STL emits this Clang-18 builtin from core allocator / string / `call_once` headers, which the pinned PyPI libclang (≤18) can't resolve; because those headers reach nearly every translation unit, the broken parse crashed symbol extraction. Also narrow a numpy-scalar union in the `Kde1d` plot helper so `make check` (`ty`) passes (#224).
 - Migrate macOS CI to `macos-15` and re-add `macos-15-intel` (`MACOSX_DEPLOYMENT_TARGET=10.13` for nanobind's aligned `new`/`delete`); wheel matrix is now 5 platforms × 3 ABI (15 wheels).
+- Fix the source build against Eigen 5.x (e.g. conda-forge `eigen>=5`): its CMake package exposes the include path only through the `Eigen3::Eigen` target and no longer sets the legacy `EIGEN3_INCLUDE_DIR`, leaving `docstr.hpp` generation (and the compile) unable to find `<Eigen/Dense>`. Derive `EIGEN3_INCLUDE_DIR` from the target's `INTERFACE_INCLUDE_DIRECTORIES` when unset.
 
 ### Bug fixes in `pyvinecopulib`
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,19 @@ if(DEFINED ENV{EIGEN3_INCLUDE_DIR})
   set(EIGEN3_INCLUDE_DIR $ENV{EIGEN3_INCLUDE_DIR})
 endif()
 
+# Eigen's modern CMake package (notably Eigen 5.x on conda-forge) exposes the
+# include path only via the Eigen3::Eigen target and no longer sets the legacy
+# EIGEN3_INCLUDE_DIR variable that findDependencies.cmake (external_includes)
+# and the docstr.hpp generator below rely on. Derive it from the target so both
+# the compile and the libclang docstring pass find <Eigen/Dense>.
+if(NOT DEFINED EIGEN3_INCLUDE_DIR)
+  find_package(Eigen3 QUIET CONFIG)
+  if(TARGET Eigen3::Eigen)
+    get_target_property(EIGEN3_INCLUDE_DIR Eigen3::Eigen
+                        INTERFACE_INCLUDE_DIRECTORIES)
+  endif()
+endif()
+
 if(DEFINED ENV{Boost_INCLUDE_DIR})
   set(Boost_INCLUDE_DIRS $ENV{Boost_INCLUDE_DIR})
 endif()
@@ -119,12 +132,11 @@ set(DOCSTR_OUTPUT "${CMAKE_SOURCE_DIR}/src/include/docstr.hpp")
 # on every platform: it works on manylinux / Windows but misses Alpine's
 # libstdc++ layout (musllinux) and the macOS SDK's libc++. Without them the
 # headers fail to parse, the AST is partial, and docstr.hpp is generated with
-# whole symbols missing / overloads mis-named — surfacing only as cryptic
-# "no member named ..." compile errors. We feed libclang the compiler's own
-# implicit system include dirs (which carry the C++ stdlib AND the builtin /
-# intrinsic headers like stddef.h, xmmintrin.h, arm_neon.h). This whole block
-# is gated to non-MSVC: Windows builds green today and must not be fed MSVC's
-# include dirs.
+# whole symbols missing / overloads mis-named — surfacing only as cryptic "no
+# member named ..." compile errors. We feed libclang the compiler's own implicit
+# system include dirs (which carry the C++ stdlib AND the builtin / intrinsic
+# headers like stddef.h, xmmintrin.h, arm_neon.h). This whole block is gated to
+# non-MSVC: Windows builds green today and must not be fed MSVC's include dirs.
 set(DOCSTR_SYS_INCLUDES "")
 set(DOCSTR_CLANG_ARGS "")
 if(NOT MSVC)
@@ -132,8 +144,8 @@ if(NOT MSVC)
   # relative to the gcc dir). These supply both the C++ stdlib and the builtin/
   # intrinsic headers, and MUST precede Eigen/Boost below: system Boost resolves
   # to `/usr/include`, and a bare `/usr/include` placed before the libstdc++ dir
-  # breaks `<cmath>`'s `#include_next <math.h>` ("'math.h' file not found").
-  # We do NOT drop the gcc/clang builtin dirs: libclang emits ~100 harmless
+  # breaks `<cmath>`'s `#include_next <math.h>` ("'math.h' file not found"). We
+  # do NOT drop the gcc/clang builtin dirs: libclang emits ~100 harmless
   # vendor-intrinsic errors when it parses them (version-specific builtins), but
   # those are error-severity, not fatal — they don't truncate the AST or affect
   # the declarations docstrings are read from (see generate_docstring.py).


### PR DESCRIPTION
## Problem

The documented conda source build (`mamba create ... eigen`, `make sync`) fails on a fresh env now that conda-forge ships **Eigen 5.0.1**:

```
kde1d/tools.hpp:3:10: fatal error: 'Eigen/Dense' file not found
```

Eigen's modern CMake package exposes the include path *only* through the `Eigen3::Eigen` target (`INTERFACE_INCLUDE_DIRECTORIES = <prefix>/include/eigen3`) and **no longer sets the legacy `EIGEN3_INCLUDE_DIR` variable**. The repo relies on that variable in two places:

- `CMakeLists.txt` passes `-isystem "${EIGEN3_INCLUDE_DIR}"` to the libclang docstring generator → becomes an empty `-isystem ""`.
- `lib/vinecopulib/cmake/findDependencies.cmake` folds it into `external_includes` for the compile.

With it empty, `<Eigen/Dense>` (which lives under `include/eigen3/`, not `include/`) can't be found. Older Eigen 3.x conda packages set the variable, which is why this only surfaced on a freshly-created env.

## Fix

Derive `EIGEN3_INCLUDE_DIR` from the `Eigen3::Eigen` target when it isn't already set (env-var override still wins), *before* `findDependencies.cmake` and the docstr generator consume it. One line fixes both the compile and the docstring pass. No `lib/` submodule changes.

## Verification

Clean `make sync` (both the isolated `uv sync` build and the `--no-build-isolation` build) with `EIGEN3_INCLUDE_DIR` unset, in a conda env with Eigen 5.0.1 — builds and imports cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)