### PR TITLE
ci: fail fast on lint before the wheel matrix starts

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -24,7 +24,32 @@ env:
 
 jobs:
 
+  lint:
+    # Gates the wheel matrix: 15 cibuildwheel legs should not start behind a
+    # formatting error. `ty` is not here — it reads the .pyi stubs a build
+    # generates, so it stays in `build_sdist` where the editable install exists.
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: pyproject.toml
+      - name: Install lint tooling
+        run: uv sync --no-install-project --group dev
+      - name: Lint, format-check, and security-lint
+        env:
+          UV_NO_SYNC: "1"
+        run: make lint
+
   build:
+    needs: [lint]
     strategy:
       fail-fast: false
       matrix:
@@ -420,7 +445,7 @@ jobs:
 
   build_sdist:
     runs-on: ubuntu-latest
-    # needs: build
+    needs: [lint]
     steps:
       - name: Checkout project
         uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Thin wrappers around `uv`. See CONTRIBUTING.md.
-.PHONY: help sync clean check format test test-examples docs sdist build notebooks
+.PHONY: help sync clean lint check format test test-examples docs sdist build notebooks
 .DEFAULT_GOAL := help
 
 UV := uv
@@ -16,11 +16,13 @@ clean: ## Wipe build artifacts and Python caches
 	rm -rf build/ dist/ *.egg-info/
 	find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
 
-check: ## Read-only lint + format-check + type-check + security-lint (CI-safe)
+lint: ## Lint + format-check + security-lint; needs no compiled extension
 	$(UV) run ruff check src tests
 	$(UV) run ruff format --check src tests
-	$(UV) run ty check
 	$(UV) run bandit -c pyproject.toml -q -r src/pyvinecopulib scripts
+
+check: lint ## `lint` plus the type check, which reads the generated .pyi stubs
+	$(UV) run ty check
 
 format: ## Apply ruff autofixes + format
 	$(UV) run ruff check --fix src tests


### PR DESCRIPTION
Stacked on #248.

## Why

A formatting error currently costs a full 15-leg cibuildwheel matrix before
anyone sees it. The vinecopulib-1.0.0 port that follows is a long stack of pull
requests, so that cost is paid many times over.

## What changed

- Split the `Makefile` target in two: `lint` (ruff check, ruff format --check,
  bandit) needs no compiled extension; `check` is `lint` plus `ty`.
- Add a standalone `lint` CI job that syncs only `--group dev` with
  `--no-install-project`, so it never triggers a C++ build.
- `build` and `build_sdist` now `needs: [lint]`. `check_wheels`,
  `verify_docs_build` and `install_and_unit_test` inherit it through `build`.
- `build_sdist`'s `# needs: build` was commented out; it now has a real
  dependency.

`ty` deliberately stays in `build_sdist`: it reads the `__init__.pyi` stubs that
only a build produces, so it cannot run in a build-free job. Splitting it out
would mean either a wrong type check or a C++ build in the "fast" gate.

No `paths-ignore` filter — a required check that is *skipped* rather than passed
blocks a merge permanently.

## Testing

`make lint` passes locally. The acceptance check is behavioral: introduce a
deliberate ruff error and confirm the run fails in under ~90s with zero wheel
legs started.

🤖 Generated with [Claude Code](https://claude.com/claude-code)