### PR TITLE
docs: adopt the main-only branching model and document releases

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -236,8 +236,17 @@ jobs:
           enable-cache: true
       - name: Install Graphviz + Pandoc
         run: |
-          sudo apt-get update
-          sudo apt-get install -y graphviz pandoc
+          # Each attempt is bounded: a slow apt mirror otherwise holds the
+          # runner until the job timeout rather than failing.
+          apt_retry() {
+            for attempt in 1 2 3; do
+              sudo timeout 300 apt-get "$@" && return 0
+              sleep $((attempt * 15))
+            done
+            return 1
+          }
+          apt_retry update
+          apt_retry install -y graphviz pandoc
       - name: Download built wheel (cp311 manylinux ubuntu)
         uses: actions/download-artifact@v4
         with:
@@ -317,8 +326,8 @@ jobs:
               -maxdepth 3 -name dot.exe 2>/dev/null | grep -q .
           }
           if [[ "${{ matrix.cfg.os }}" == "ubuntu-latest" ]]; then
-            sudo apt-get update
-            retry sudo apt-get install -y graphviz
+            retry sudo timeout 300 apt-get update
+            retry sudo timeout 300 apt-get install -y graphviz
           elif [[ "${{ matrix.cfg.os }}" == macos-* ]]; then
             brew list graphviz >/dev/null 2>&1 || retry brew install graphviz
           elif [[ "${{ matrix.cfg.os }}" == "windows-latest" ]]; then
@@ -416,8 +425,15 @@ jobs:
           cache-dependency-glob: pyproject.toml
       - name: Install Graphviz
         run: |
-          sudo apt-get update
-          sudo apt-get install -y graphviz
+          apt_retry() {
+            for attempt in 1 2 3; do
+              sudo timeout 300 apt-get "$@" && return 0
+              sleep $((attempt * 15))
+            done
+            return 1
+          }
+          apt_retry update
+          apt_retry install -y graphviz
       - name: Download built wheel (cp311 ABI3, ubuntu)
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -47,6 +47,8 @@ jobs:
         env:
           UV_NO_SYNC: "1"
         run: make lint
+      - name: Check the version metadata agrees
+        run: python3 scripts/check_version.py
 
   build:
     needs: [lint]

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -30,6 +30,7 @@ jobs:
     # generates, so it stays in `build_sdist` where the editable install exists.
     name: Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python 3.11
@@ -103,6 +104,7 @@ jobs:
 
     name: Build and test on ${{ matrix.cfg.os }} for cp${{ matrix.python }}-${{ matrix.cfg.cibw_id }}
     runs-on: ${{ matrix.cfg.os }}
+    timeout-minutes: 45
 
     steps:
       - name: Checkout project
@@ -180,6 +182,7 @@ jobs:
   check_wheels:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment: pypi
     permissions:
       id-token: write
@@ -223,6 +226,7 @@ jobs:
     name: Verify docs build (RTD mirror)
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout project
         uses: actions/checkout@v4
@@ -273,6 +277,7 @@ jobs:
   install_and_unit_test:
     needs: build
     runs-on: ${{ matrix.cfg.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -405,6 +410,7 @@ jobs:
       github.event_name == 'pull_request'
       && contains(github.event.pull_request.labels.*.name, 'regenerate-notebooks')
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write  # required to push the auto-commit back to the PR branch
     steps:
@@ -463,6 +469,7 @@ jobs:
 
   build_sdist:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     needs: [lint]
     steps:
       - name: Checkout project
@@ -532,6 +539,7 @@ jobs:
   upload_to_pypi:
     needs: [build_sdist, check_wheels, install_and_unit_test]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     environment: pypi
     permissions:
       id-token: write

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -522,6 +522,15 @@ jobs:
       actions: read
       contents: read
     steps:
+      # Before the artifacts land: checkout cleans the workspace.
+      - uses: actions/checkout@v4
+      # PyPI never re-accepts a version number, so a tag that disagrees with
+      # the metadata is unrecoverable. The `lint` job runs the same check on
+      # every pull request, but without a tag to compare against and while the
+      # changelog heading is still legitimately `(unreleased)`.
+      - name: Check the version metadata matches the tag
+        if: ${{ startsWith(github.event.ref, 'refs/tags') }}
+        run: python3 scripts/check_version.py --released --tag "$GITHUB_REF_NAME"
       - name: Set up uv
         uses: astral-sh/setup-uv@v6
         with:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -139,6 +139,12 @@ jobs:
           # wdm and kde1d ship as lib/ submodules; lcov is only for C++ coverage.
           wdm: "false"
           lcov: "false"
+          # The action's default apt-installs g++/clang on the host. cibuildwheel
+          # compiles inside the manylinux/musllinux container with its own
+          # toolchain, and the other ubuntu jobs only install prebuilt wheels, so
+          # the host compilers are never used -- and that apt call has hung the
+          # job repeatedly.
+          update_compilers_ubuntu: "false"
       - name: Clean build artefacts
         shell: bash
         run: |
@@ -494,6 +500,12 @@ jobs:
           # wdm and kde1d ship as lib/ submodules; lcov is only for C++ coverage.
           wdm: "false"
           lcov: "false"
+          # The action's default apt-installs g++/clang on the host. cibuildwheel
+          # compiles inside the manylinux/musllinux container with its own
+          # toolchain, and the other ubuntu jobs only install prebuilt wheels, so
+          # the host compilers are never used -- and that apt call has hung the
+          # job repeatedly.
+          update_compilers_ubuntu: "false"
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.8.0
+## 0.8.0 (unreleased)
 
 ### Breaking API changes in `pyvinecopulib`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,11 +145,11 @@ Pull requests go to `main`. There is no long-lived development branch.
   in a stack outside `gh stack`.
 
 The policy behind these — including when *not* to merge — is in
-[AGENTS.md](AGENTS.md#branching-and-releases).
+[AGENTS.md](https://github.com/vinecopulib/pyvinecopulib/blob/main/AGENTS.md#branching-and-releases).
 
 ## Release process
 
-Releases are tags on `main`. See [docs/releasing.md](docs/releasing.md) for the
+Releases are tags on `main`. See [docs/releasing.md](https://github.com/vinecopulib/pyvinecopulib/blob/main/docs/releasing.md) for the
 checklist; the short version is: date the `(unreleased)` heading in
 `CHANGELOG.md`, bump the version, merge, then tag. Pushing a `v*` tag publishes
 to PyPI, and **PyPI never re-accepts a version number** — a mistagged release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,7 @@ uv run ty check src tests
 
 ## Dependency layout
 
-User-facing extras (`doc`, `examples`, `sklearn`) live under
+User-facing extras (`doc`, `examples`, `sklearn`, `torch`) live under
 `[project.optional-dependencies]` — installable via
 `pip install pyvinecopulib[<extra>]`.
 
@@ -83,7 +83,7 @@ Developer-only deps live under PEP 735 `[dependency-groups]`:
 | `build` | `[build-system].requires` + `ninja` + `cmake`. |
 | `test` | pytest stack. |
 | `notebooks` | jupyter, nbmake, nbconvert, nbformat. |
-| `dev` | ruff, ty, pre-commit, twine (`include-group = "build"`). |
+| `dev` | ruff, ty, bandit, pre-commit, twine (`include-group = "build"`). |
 
 Combine groups and extras as needed: `uv sync --group test --extra examples`.
 
@@ -94,7 +94,8 @@ Combine groups and extras as needed: `uv sync --group test --extra examples`.
 | Command | Purpose |
 |---|---|
 | `make sync` | Install all deps + editable build + pre-commit hooks. |
-| `make check` | Read-only lint + format-check + ty. |
+| `make lint` | Lint + format-check + security-lint; needs no compiled extension. |
+| `make check` | `make lint` plus `ty`, which reads the generated `.pyi` stubs. |
 | `make format` | Apply ruff autofixes + format. |
 | `make test` / `make test-examples` | Pytest suite / notebook tests. |
 | `make docs` | Sphinx build (-W). |
@@ -111,24 +112,48 @@ general whitespace/TOML/JSON checks. `make sync` installs them.
 
 `.github/workflows/pypi.yml` is the single workflow. Jobs:
 
-- **`build`** — cibuildwheel matrix (12 wheels: Linux glibc/musl, macOS arm64,
-  Windows × cp310/cp311/cp312-ABI3).
+- **`lint`** — ruff, ruff format and bandit; gates the wheel matrix so a
+  formatting error does not cost 15 cibuildwheel legs.
+- **`build`** — cibuildwheel matrix (15 wheels: Linux glibc/musl, macOS x86_64,
+  macOS arm64, Windows × cp310/cp311/cp312-ABI3).
 - **`check_wheels`** — counts and twine-checks artifacts.
 - **`verify_docs_build`** — RTD-mirror doc build with `-W`.
 - **`install_and_unit_test`** — installs each wheel and runs pytest + notebook
   tests.
-- **`regenerate_notebooks`** — fires on PRs to `main` (or any PR labelled
-  `regenerate-notebooks`); auto-commits refreshed outputs.
+- **`regenerate_notebooks`** — refreshes stored notebook outputs and
+  auto-commits them. Fires only on the `regenerate-notebooks` label: it pushes
+  to the pull request's head branch, which would rewrite the base of anything
+  stacked above it. Push a commit after labelling — the trigger does not
+  include `labeled`.
 - **`build_sdist`** — runs `make check && make sdist` and tests the installed
   sdist.
 - **`upload_to_pypi`** — publishes on tag push.
 
+## Pull requests
+
+Pull requests go to `main`. There is no long-lived development branch.
+
+- Subjects are `type(scope): subject`, with `!` marking a breaking change.
+  Scopes are the subpackages and areas: `core`, `families`, `utils`, `sklearn`,
+  `torch`, `bicop`, `vinecop`, `build`, `ci`, `docs`, `deps`, `examples`.
+- Merges are squashed: one pull request, one commit on `main`. The squashed
+  message is what explains the change, since that is what `git log` — and hence
+  `CHANGELOG.md` — is read from.
+- For work that builds on work still in review, **stack** the pull requests:
+  each branches off the previous one and targets it, managed with `gh stack`
+  (`init` / `add` / `submit` / `sync` / `rebase`). Nothing may push to a branch
+  in a stack outside `gh stack`.
+
+The policy behind these — including when *not* to merge — is in
+[AGENTS.md](AGENTS.md#branching-and-releases).
+
 ## Release process
 
-1. Feature branches → PR → `dev`.
-2. PR `dev → main` — `regenerate_notebooks` refreshes outputs automatically.
-3. Merge and tag on `main` — `upload_to_pypi` ships to PyPI and Read the Docs
-   picks up the tag.
+Releases are tags on `main`. See [docs/releasing.md](docs/releasing.md) for the
+checklist; the short version is: date the `(unreleased)` heading in
+`CHANGELOG.md`, bump the version, merge, then tag. Pushing a `v*` tag publishes
+to PyPI, and **PyPI never re-accepts a version number** — a mistagged release
+is permanent.
 
 ## Code style
 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,6 @@ To build the documentation locally:
 
 ```bash
 make docs           # one-shot HTML build → docs/_build/html/
-make docs-serve     # live-reload dev server (sphinx-autobuild)
 ```
 
 ## Contributing

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -179,7 +179,9 @@ master_doc = "index"
 
 # Don't exclude `_generate` — autosummary writes stubs there and sphinx
 # reads them back as source documents.
-exclude_patterns = ["_build", "**/.ipynb_checkpoints"]
+# `releasing.md` is a maintainer checklist that lives next to the docs for
+# discoverability, not a page of the user site.
+exclude_patterns = ["_build", "**/.ipynb_checkpoints", "releasing.md"]
 
 project = "pyvinecopulib"
 copyright = "2024, Thomas Nagler and Thibault Vatter"

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,65 @@
+# Releasing pyvinecopulib
+
+Maintainer checklist. This file is not part of the rendered user site.
+
+Releases are tags on `main`. In the steady state the top heading of
+`CHANGELOG.md` carries `(unreleased)`, so a released version is never
+indistinguishable from an unreleased one.
+
+## Checklist
+
+1. **`main` is green** and every pull request intended for the release is
+   merged.
+
+2. **Open the release pull request.** In one commit:
+   - retitle the top `CHANGELOG.md` heading from `(unreleased)` to the release
+     date, e.g. `## 1.0.0 (2026-08-20)`;
+   - set the version in `pyproject.toml` (`[project].version`), which is the
+     single source of truth — CMake reads it through `SKBUILD_PROJECT_VERSION`
+     and it reaches users as `pyvinecopulib.__version__`;
+   - if `CITATION.cff` or a `version` field in `.zenodo.json` has been added
+     by then, set the matching version there too.
+
+3. **Check the metadata agrees**: `uv run python scripts/check_version.py`.
+   CI runs the same check on every pull request.
+
+4. **Merge**, then tag the merge commit:
+
+   ```bash
+   git checkout main && git pull
+   git tag -a vX.Y.Z -m "pyvinecopulib X.Y.Z"
+   git push origin vX.Y.Z
+   ```
+
+   > **The tag push publishes to PyPI, and PyPI never re-accepts a version
+   > number.** A mistagged release cannot be undone — only superseded by a new
+   > version. Confirm the tag points at the commit you mean before pushing.
+
+5. **Confirm the release landed**: wheels and the sdist on PyPI, the GitHub
+   release created from the changelog section, Read the Docs built the tag with
+   `stable` repointed at it, and the Zenodo deposition.
+
+6. **Open the next cycle immediately.** Add a fresh
+   `## X.Y+1.0 (unreleased)` heading to `CHANGELOG.md` in a follow-up pull
+   request, so the next change has somewhere to go.
+
+7. **If the release surfaced a problem in the C++ library**, file it upstream
+   rather than working around it here — the docstrings, signatures and CMake
+   seams all belong to `vinecopulib`.
+
+## What is automated
+
+| Check | When |
+|---|---|
+| `scripts/check_version.py` | every pull request, via the `lint` job |
+| wheels, sdist, tests, docs | every pull request |
+| publish to PyPI + GitHub release | on a `v*` tag push |
+| release drift (a dated changelog heading with no tag) | weekly |
+
+## Version numbers
+
+`pyvinecopulib` follows semantic versioning and tracks — but does not have to
+match — the pinned `lib/vinecopulib` version. Honor the
+[stability tiers](../AGENTS.md#stability-tiers): `core` / `families` / `utils`
+prefer a deprecation alias over a hard break, while `sklearn` and `torch` may
+break between minor releases.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -53,8 +53,8 @@ indistinguishable from an unreleased one.
 |---|---|
 | `scripts/check_version.py` | every pull request, via the `lint` job |
 | wheels, sdist, tests, docs | every pull request |
+| `scripts/check_version.py --released --tag` | on a `v*` tag push, before publishing |
 | publish to PyPI + GitHub release | on a `v*` tag push |
-| release drift (a dated changelog heading with no tag) | weekly |
 
 ## Version numbers
 

--- a/scripts/check_version.py
+++ b/scripts/check_version.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Check that every place the version is written agrees.
+
+The source of truth is ``[project].version`` in ``pyproject.toml``. Everything
+else must match it: the top ``CHANGELOG.md`` heading, and ``CITATION.cff`` /
+``.zenodo.json`` when they carry a version.
+
+Reports every mismatch in one run, rather than stopping at the first.
+
+Usage
+-----
+    python scripts/check_version.py
+    python scripts/check_version.py --released
+    python scripts/check_version.py --released --tag v1.0.0
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+#: ``## 1.0.0 (unreleased)`` or ``## 1.0.0 (2026-08-20)``; the date form is
+#: what marks a version as released.
+_HEADING = re.compile(
+  r"^##\s+(?P<version>\d+\.\d+\.\d+)\s*(?:\((?P<state>[^)]*)\))?\s*$"
+)
+
+
+def _project_version() -> str:
+  with (ROOT / "pyproject.toml").open("rb") as f:
+    return str(tomllib.load(f)["project"]["version"])
+
+
+def _changelog_heading() -> tuple[str, str] | None:
+  """Return ``(version, state)`` of the newest ``CHANGELOG.md`` heading."""
+  for line in (ROOT / "CHANGELOG.md").read_text().splitlines():
+    match = _HEADING.match(line)
+    if match:
+      return match["version"], (match["state"] or "").strip()
+  return None
+
+
+def _citation_version() -> str | None:
+  path = ROOT / "CITATION.cff"
+  if not path.exists():
+    return None
+  for line in path.read_text().splitlines():
+    if line.startswith("version:"):
+      return line.split(":", 1)[1].strip().strip("\"'")
+  return None
+
+
+def _zenodo_version() -> str | None:
+  path = ROOT / ".zenodo.json"
+  if not path.exists():
+    return None
+  return json.loads(path.read_text()).get("version")
+
+
+def main() -> int:
+  parser = argparse.ArgumentParser(description=__doc__)
+  parser.add_argument(
+    "--released",
+    action="store_true",
+    help="require the changelog heading to be dated, not '(unreleased)'",
+  )
+  parser.add_argument(
+    "--tag", help="require the version to match this tag (e.g. v1.0.0)"
+  )
+  args = parser.parse_args()
+
+  version = _project_version()
+  problems: list[str] = []
+
+  heading = _changelog_heading()
+  if heading is None:
+    problems.append("CHANGELOG.md has no '## X.Y.Z' heading")
+  else:
+    changelog_version, state = heading
+    if changelog_version != version:
+      problems.append(
+        f"CHANGELOG.md top heading is {changelog_version}, "
+        f"pyproject.toml says {version}"
+      )
+    elif not state:
+      problems.append(
+        f"CHANGELOG.md heading '## {changelog_version}' says neither "
+        "'(unreleased)' nor a release date, so a released version cannot be "
+        "told from an unreleased one"
+      )
+    elif args.released and state.lower() == "unreleased":
+      problems.append(
+        f"CHANGELOG.md still marks {changelog_version} as unreleased; "
+        "date the heading before tagging"
+      )
+    elif not args.released and state.lower() != "unreleased":
+      # Not fatal: the release pull request dates the heading before the tag
+      # exists, so this state is expected for exactly one commit.
+      print(
+        f"note: CHANGELOG.md marks {changelog_version} as released "
+        f"({state}); expected only in a release pull request",
+        file=sys.stderr,
+      )
+
+  for name, found in (
+    ("CITATION.cff", _citation_version()),
+    (".zenodo.json", _zenodo_version()),
+  ):
+    if found is not None and found != version:
+      problems.append(f"{name} says {found}, pyproject.toml says {version}")
+
+  if args.tag is not None:
+    expected = f"v{version}"
+    if args.tag != expected:
+      problems.append(f"tag is {args.tag}, pyproject.toml implies {expected}")
+
+  for problem in problems:
+    print(f"error: {problem}", file=sys.stderr)
+  if problems:
+    return 1
+
+  print(f"version {version} is consistent")
+  return 0
+
+
+if __name__ == "__main__":
+  raise SystemExit(main())


### PR DESCRIPTION
Stacked on #252.

## What changed

**`CONTRIBUTING.md`** loses the `dev` → `main` release two-step and gains a
*Pull requests* section: subjects are `type(scope): subject`, merges are
squashed (one pull request, one commit — the squashed message is what `git log`,
and hence the changelog, is read from), and dependent work is **stacked** rather
than merged to unblock itself. The policy behind those rules — including when
*not* to merge — stays in `AGENTS.md`; this file keeps the mechanics and links
to it.

**`docs/releasing.md`** is new: a maintainer checklist, deliberately *not* in the
rendered user site. It carries the warning that matters most — a `v*` tag push
publishes to PyPI, and **PyPI never re-accepts a version number**, so a
mistagged release is permanent — and ends by opening the next `(unreleased)`
cycle immediately, which is how 0.8.0 came to be written up but never shipped.

**`scripts/check_version.py`** is new, so the checklist has something to check.
The source of truth is `[project].version`; the changelog heading, and
`CITATION.cff` / `.zenodo.json` when they carry a version, must agree. It reports
every mismatch in one pass and runs in the `lint` job.

It also refuses a heading that says neither `(unreleased)` nor a date — which is
exactly the state `## 0.8.0` was in, indistinguishable from a released version.
That heading now reads `## 0.8.0 (unreleased)`, which is simply what it is:
written up, never published (PyPI's latest is 0.7.6).

> The `0.8.0` → `1.0.0` rename belongs in the release pull request, not here.

## Drift corrected along the way

| claim | reality |
|---|---|
| "12 wheels" | 15 (5 platforms × 3 ABI3 builds) |
| `dev` group: ruff, ty, pre-commit, twine | also bandit |
| user extras: `doc`, `examples`, `sklearn` | also `torch` |
| `make check` = lint + format + ty | `make lint` and `make check` since #249 |
| `regenerate_notebooks` fires on PRs to `main` | label-only since #248 |
| `README.md`: `make docs-serve` | no such target — line removed |

## Testing

```
$ python scripts/check_version.py
version 0.8.0 is consistent
$ python scripts/check_version.py --released
error: CHANGELOG.md still marks 0.8.0 as unreleased; date the heading before tagging
$ python scripts/check_version.py --tag v9.9.9
error: tag is v9.9.9, pyproject.toml implies v0.8.0
```

`make lint` passes.

## Not in this pull request

Retiring the `dev` branch itself, branch protection, and the Read the Docs
default version are maintainer actions, not file changes. `main` is currently
34 commits behind `dev` with **zero** divergence (`gh api compare/main...dev` →
`ahead_by: 34, behind_by: 0`), so it fast-forwards cleanly:
`git push origin dev:main`. Doing it as a pull request would squash 34
one-per-change commits into one and destroy the history the changelog is
sourced from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)