### PR TITLE
feat(vinecop): accept an explicit conditioning set in the Rosenblatt transforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@
 
 #### NEW FEATURES
 
+- `Vinecop.rosenblatt` and `Vinecop.inverse_rosenblatt` accept an explicit `conditioning_set`, holding the named variables fixed instead of the ones at the tail of the vine order, and evaluating through a reoriented non-owning view rather than copying pair copulas ([vinecopulib#715](https://github.com/vinecopulib/vinecopulib/pull/715)). The argument is keyword-only, so `rosenblatt(u, 4)` still means `num_threads=4`.
 - `Bicop.simulate` draws one observation per parameter set: pass `parameters` (an `(n, p)` array) instead of `n`, whose row count then fixes the sample size ([vinecopulib#719](https://github.com/vinecopulib/vinecopulib/pull/719)). `parameters` is keyword-only, so the positional `simulate(n, qrng, seeds)` keeps its meaning, and rejects a 1-d array, which would otherwise be read as a single row. `num_threads` applies only to this form.
 - Early exit in vine selection when the structure is already a tree, avoiding redundant work in `select` ([vinecopulib#661](https://github.com/vinecopulib/vinecopulib/pull/661)).
 - Per-family parameter / rotation / tail-dependence documentation on the `BicopFamily` enum members, surfaced through the Python `families` subpackage (#214, [vinecopulib#668](https://github.com/vinecopulib/vinecopulib/pull/668)).

--- a/src/include/vinecop/class.hpp
+++ b/src/include/vinecop/class.hpp
@@ -261,8 +261,6 @@ ones. Continuous, all-parametric vines only.
   const std::string scores_cov_perobs_doc =
       std::string(vinecop_doc.scores_cov.doc_3args) + per_obs_note;
 
-  // Hand-written: the C++ facade returns an ``RVineTrees`` (no Python
-  // equivalent); the Python method returns nested ``[tree][edge]`` dicts.
   // The Rosenblatt transforms accept an explicit conditioning set
   // (vinecopulib#715), which evaluates the vine through a reoriented,
   // non-owning view rather than copying pair copulas. It is keyword-only:
@@ -291,6 +289,8 @@ the model.
       std::string(vinecop_doc.inverse_rosenblatt.doc_2args) +
       conditioning_set_note;
 
+  // Hand-written: the C++ facade returns an ``RVineTrees`` (no Python
+  // equivalent); the Python method returns nested ``[tree][edge]`` dicts.
   const char* get_trees_doc =
       R"""(Return the fitted vine as a nested list of trees.
 

--- a/src/include/vinecop/class.hpp
+++ b/src/include/vinecop/class.hpp
@@ -270,6 +270,7 @@ ones. Continuous, all-parametric vines only.
   // C++ order positionally would silently rebind `rosenblatt(u, 4)`.
   const std::string conditioning_set_note =
       R"""(
+
 Notes
 -----
 ``conditioning_set`` is a list of 1-based variable indices, holding those

--- a/src/include/vinecop/class.hpp
+++ b/src/include/vinecop/class.hpp
@@ -263,6 +263,33 @@ ones. Continuous, all-parametric vines only.
 
   // Hand-written: the C++ facade returns an ``RVineTrees`` (no Python
   // equivalent); the Python method returns nested ``[tree][edge]`` dicts.
+  // The Rosenblatt transforms accept an explicit conditioning set
+  // (vinecopulib#715), which evaluates the vine through a reoriented,
+  // non-owning view rather than copying pair copulas. It is keyword-only:
+  // C++ puts it in position 2, which here is `num_threads`, so mirroring the
+  // C++ order positionally would silently rebind `rosenblatt(u, 4)`.
+  const std::string conditioning_set_note =
+      R"""(
+Notes
+-----
+``conditioning_set`` is a list of 1-based variable indices, holding those
+variables fixed instead of the ones at the tail of the vine order. It does not
+subset ``u``, which stays the full matrix; what changes is which conditional
+distributions the output columns represent. Passing the order tail itself is
+the identity and is evaluated on the original representation.
+
+The set must be admissible as a sampling-order tail of this vine, and the vine
+must not be truncated; otherwise ``RuntimeError`` is raised, naming
+``FitControlsVinecop.conditioning_set`` as the way to fit a vine that admits
+it. This is the same relabeling ``Vinecop.reorient`` applies, without mutating
+the model.
+)""";
+  const std::string rosenblatt_doc =
+      std::string(vinecop_doc.rosenblatt.doc_4args) + conditioning_set_note;
+  const std::string inverse_rosenblatt_doc =
+      std::string(vinecop_doc.inverse_rosenblatt.doc_2args) +
+      conditioning_set_note;
+
   const char* get_trees_doc =
       R"""(Return the fitted vine as a nested list of trees.
 
@@ -483,19 +510,38 @@ RVineStructure.get_trees : The bare structure decomposition (no pair-copulas).
            nb::call_guard<nb::gil_scoped_release>())
       // `u` is taken by value and moved: the implementation uses it as a
       // working buffer, and a const reference would force an n x d copy.
-      .def("rosenblatt",
-           static_cast<Eigen::MatrixXd (Vinecop::*)(
-               Eigen::MatrixXd, const size_t, bool, std::vector<int>) const>(
-               &Vinecop::rosenblatt),
-           "u"_a, "num_threads"_a = 1, "randomize_discrete"_a = true,
-           "seeds"_a = std::vector<int>(), vinecop_doc.rosenblatt.doc_4args,
-           nb::call_guard<nb::gil_scoped_release>())
-      .def("inverse_rosenblatt",
-           static_cast<Eigen::MatrixXd (Vinecop::*)(const Eigen::MatrixXd&,
-                                                    const size_t) const>(
-               &Vinecop::inverse_rosenblatt),
-           "u"_a, "num_threads"_a = 1, vinecop_doc.inverse_rosenblatt.doc_2args,
-           nb::call_guard<nb::gil_scoped_release>())
+      // `u` is taken by value and moved: the implementation uses it as a
+      // working buffer, and a const reference would force an n x d copy.
+      .def(
+          "rosenblatt",
+          [](const Vinecop& self, Eigen::MatrixXd u, size_t num_threads,
+             bool randomize_discrete, const std::vector<int>& seeds,
+             const std::optional<std::vector<size_t>>& conditioning_set)
+              -> Eigen::MatrixXd {
+            nb::gil_scoped_release release;
+            if (conditioning_set) {
+              return self.rosenblatt(std::move(u), *conditioning_set,
+                                     num_threads, randomize_discrete, seeds);
+            }
+            return self.rosenblatt(std::move(u), num_threads,
+                                   randomize_discrete, seeds);
+          },
+          "u"_a, "num_threads"_a = 1, "randomize_discrete"_a = true,
+          "seeds"_a = std::vector<int>(), nb::kw_only(),
+          "conditioning_set"_a = nb::none(), rosenblatt_doc.c_str())
+      .def(
+          "inverse_rosenblatt",
+          [](const Vinecop& self, const Eigen::MatrixXd& u, size_t num_threads,
+             const std::optional<std::vector<size_t>>& conditioning_set)
+              -> Eigen::MatrixXd {
+            nb::gil_scoped_release release;
+            if (conditioning_set) {
+              return self.inverse_rosenblatt(u, *conditioning_set, num_threads);
+            }
+            return self.inverse_rosenblatt(u, num_threads);
+          },
+          "u"_a, "num_threads"_a = 1, nb::kw_only(),
+          "conditioning_set"_a = nb::none(), inverse_rosenblatt_doc.c_str())
       .def("reorient", &Vinecop::reorient, "conditioning_set"_a,
            vinecop_doc.reorient.doc, nb::call_guard<nb::gil_scoped_release>())
       .def(

--- a/tests/test_vinecop.py
+++ b/tests/test_vinecop.py
@@ -852,3 +852,15 @@ def test_rosenblatt_rejects_inadmissible_conditioning_set(bad) -> None:
   cop, u = _cop_and_data()
   with pytest.raises(RuntimeError):
     cop.rosenblatt(u, conditioning_set=bad)
+
+
+def test_rosenblatt_conditioning_set_rejects_truncated_vine() -> None:
+  # The reorientation needs every tree, so a truncated vine cannot serve an
+  # arbitrary conditioning set even when the set itself is admissible.
+  u = pv.to_pseudo_obs(random_data(5, 400))
+  cop = pv.Vinecop.from_data(u, controls=pv.FitControlsVinecop(trunc_lvl=2))
+
+  with pytest.raises(RuntimeError):
+    cop.rosenblatt(u, conditioning_set=[1, 2])
+  with pytest.raises(RuntimeError):
+    cop.inverse_rosenblatt(u, conditioning_set=[1, 2])

--- a/tests/test_vinecop.py
+++ b/tests/test_vinecop.py
@@ -779,3 +779,76 @@ def test_fit_controls_vinecop_from_bicop_controls() -> None:
     family_set=[pv.families.clayton]
   )
   assert controls.family_set == [pv.families.clayton]
+
+
+def _cop_and_data(d: int = 5, n: int = 400):
+  u = pv.to_pseudo_obs(random_data(d, n))
+  return pv.Vinecop.from_data(u), u
+
+
+def test_rosenblatt_conditioning_set_order_tail_is_identity() -> None:
+  # Conditioning on the set the vine order already ends with is the identity:
+  # upstream evaluates it on the original representation.
+  cop, u = _cop_and_data()
+  tail = [int(v) for v in cop.structure.order][-2:]
+
+  np.testing.assert_array_equal(
+    cop.rosenblatt(u, conditioning_set=tail), cop.rosenblatt(u)
+  )
+  w = cop.rosenblatt(u)
+  np.testing.assert_array_equal(
+    cop.inverse_rosenblatt(w, conditioning_set=tail),
+    cop.inverse_rosenblatt(w),
+  )
+
+
+def test_rosenblatt_conditioning_set_round_trip() -> None:
+  # The inverse transform undoes the forward one under the same set.
+  cop, u = _cop_and_data()
+  tail = [int(v) for v in cop.structure.order][-2:]
+  w = cop.rosenblatt(u, conditioning_set=tail)
+  back = cop.inverse_rosenblatt(w, conditioning_set=tail)
+  np.testing.assert_allclose(back, u, rtol=1e-8, atol=1e-8)
+
+
+def test_rosenblatt_conditioning_set_matches_reorient() -> None:
+  # The argument applies the same relabeling as `reorient`, without mutating
+  # the model. Not every set is an admissible sampling-order tail, so fit a
+  # vine that admits this one.
+  cs = [2, 3]
+  controls = pv.FitControlsVinecop()
+  controls.conditioning_set = cs
+  u = pv.to_pseudo_obs(random_data(5, 400))
+  cop = pv.Vinecop.from_data(u, controls=controls)
+
+  order_before = [int(v) for v in cop.structure.order]
+  with_arg = cop.rosenblatt(u, conditioning_set=cs)
+
+  # The keyword form evaluates through a view and leaves the model alone;
+  # `reorient` performs the same relabeling in place.
+  assert [int(v) for v in cop.structure.order] == order_before
+  cop.reorient(cs)
+  np.testing.assert_allclose(
+    with_arg, cop.rosenblatt(u), rtol=1e-10, atol=1e-10
+  )
+
+
+def test_rosenblatt_second_positional_is_still_num_threads() -> None:
+  # C++ puts `conditioning_set` in position 2; Python keeps `num_threads`
+  # there, so `rosenblatt(u, 4)` must not silently become a conditioning set.
+  cop, u = _cop_and_data(d=4, n=200)
+  np.testing.assert_allclose(
+    cop.rosenblatt(u, 4), cop.rosenblatt(u), rtol=1e-12
+  )
+  np.testing.assert_allclose(
+    cop.inverse_rosenblatt(u, 2), cop.inverse_rosenblatt(u), rtol=1e-12
+  )
+
+
+@pytest.mark.parametrize(
+  "bad", [[], [1, 1], [0], [99], [1, 2, 3, 4, 5]], ids=str
+)
+def test_rosenblatt_rejects_inadmissible_conditioning_set(bad) -> None:
+  cop, u = _cop_and_data()
+  with pytest.raises(RuntimeError):
+    cop.rosenblatt(u, conditioning_set=bad)


### PR DESCRIPTION
Stacked on #254.

## What

`rosenblatt` and `inverse_rosenblatt` can hold a **named** set of variables
fixed, instead of whichever ones happen to sit at the tail of the vine order
(vinecopulib#715):

```python
w = cop.rosenblatt(u, conditioning_set=[2, 3])
```

The vine is evaluated through a reoriented, **non-owning view** — no pair
copulas are copied, and the model is not mutated. `u` stays the full matrix;
what changes is which conditional distributions the output columns represent.

## Why keyword-only

C++ puts `conditioning_set` in **position 2**. In the Python signature position
2 is `num_threads`. Mirroring the C++ order positionally would silently rebind

```python
cop.rosenblatt(u, 4)     # four threads … or conditioning on variable 4?
```

which is precisely the `nonparametric_grid_size` failure mode that upstream's
own migration guide singles out as "the dangerous one" — it compiles, runs, and
returns something plausible. Keyword-only removes the ambiguity, and a test pins
that `rosenblatt(u, 4)` still means `num_threads=4`.

`u` remains taken **by value and moved**: the implementation uses it as a
working buffer, and a `const&` would add an n×d copy per call.

## Tests

- conditioning on the order tail is **bit-identical** to the no-argument call
  (upstream's identity fast path);
- `inverse_rosenblatt(rosenblatt(u, cs), cs)` round-trips to `u`;
- the keyword form agrees with `reorient(cs)` followed by a plain
  `rosenblatt`, **and leaves `structure.order` unchanged** — that is the
  difference between the two;
- `rosenblatt(u, 4)` and `inverse_rosenblatt(u, 2)` still mean `num_threads`;
- an empty set, duplicates, a 0 index, an out-of-range index, and a set of size
  `d` each raise `RuntimeError`.

`32 passed` in `tests/test_vinecop.py`.

## Note on admissibility

Not every set is an admissible sampling-order tail; upstream raises and names
`FitControlsVinecop.conditioning_set` as the way to fit a vine that admits one.
The equivalence test fits such a vine rather than assuming an arbitrary set
works — which is how the first draft of that test caught itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)