### PR TITLE
feat(vinecop): condition simulation on an explicit variable set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@
 
 #### NEW FEATURES
 
+- `Vinecop.simulate_conditional` accepts an explicit `conditioning_set` and both discrete `u_cond` layouts — expanded `(n, 2k)` and compact `(n, k + k_d)` ([vinecopulib#729](https://github.com/vinecopulib/vinecopulib/pull/729)). Note that the two forms map `u_cond`'s columns differently: implicitly by the vine's order tail, explicitly by the given set.
 - `Vinecop.rosenblatt` and `Vinecop.inverse_rosenblatt` accept an explicit `conditioning_set`, holding the named variables fixed instead of the ones at the tail of the vine order, and evaluating through a reoriented non-owning view rather than copying pair copulas ([vinecopulib#715](https://github.com/vinecopulib/vinecopulib/pull/715)). The argument is keyword-only, so `rosenblatt(u, 4)` still means `num_threads=4`.
 - `Bicop.simulate` draws one observation per parameter set: pass `parameters` (an `(n, p)` array) instead of `n`, whose row count then fixes the sample size ([vinecopulib#719](https://github.com/vinecopulib/vinecopulib/pull/719)). `parameters` is keyword-only, so the positional `simulate(n, qrng, seeds)` keeps its meaning, and rejects a 1-d array, which would otherwise be read as a single row. `num_threads` applies only to this form.
 - Early exit in vine selection when the structure is already a tree, avoiding redundant work in `select` ([vinecopulib#661](https://github.com/vinecopulib/vinecopulib/pull/661)).

--- a/src/include/vinecop/class.hpp
+++ b/src/include/vinecop/class.hpp
@@ -283,6 +283,28 @@ must not be truncated; otherwise ``RuntimeError`` is raised, naming
 it. This is the same relabeling ``Vinecop.reorient`` applies, without mutating
 the model.
 )""";
+  const std::string simulate_conditional_doc =
+      std::string(vinecop_doc.simulate_conditional.doc_4args) +
+      R"""(
+Notes
+-----
+``conditioning_set`` names the variables to condition on, as 1-based indices,
+instead of taking them from the tail of the vine order. **The two forms map
+``u_cond``'s columns differently**: without the argument, column ``i``
+corresponds to the ``i``-th variable of the order tail; with it, column ``i``
+corresponds to ``conditioning_set[i]``. Adding the argument to an existing call
+can therefore permute the columns unless the set is given in the tail's order.
+
+``u_cond`` may be given in either layout: expanded, ``(n, 2 * k)``, with the
+left limits ``F(x-)`` of all ``k`` conditioning variables in the same order as
+the second block; or compact, ``(n, k + k_d)``, carrying left limits only for
+the ``k_d`` discrete ones. For continuous conditioning variables the two
+coincide at ``(n, k)``.
+
+The set must be admissible as a sampling-order tail of this vine, and the vine
+must not be truncated; otherwise ``RuntimeError`` is raised. The model is not
+mutated.
+)""";
   const std::string rosenblatt_doc =
       std::string(vinecop_doc.rosenblatt.doc_4args) + conditioning_set_note;
   const std::string inverse_rosenblatt_doc =
@@ -501,14 +523,22 @@ RVineStructure.get_trees : The bare structure decomposition (no pair-copulas).
       .def("simulate", &Vinecop::simulate, "n"_a, "qrng"_a = false,
            "num_threads"_a = 1, "seeds"_a = std::vector<int>(),
            vinecop_doc.simulate.doc, nb::call_guard<nb::gil_scoped_release>())
-      .def("simulate_conditional",
-           static_cast<Eigen::MatrixXd (Vinecop::*)(
-               const Eigen::MatrixXd&, const bool, const size_t,
-               const std::vector<int>&) const>(&Vinecop::simulate_conditional),
-           "u_cond"_a, "qrng"_a = false, "num_threads"_a = 1,
-           "seeds"_a = std::vector<int>(),
-           vinecop_doc.simulate_conditional.doc_4args,
-           nb::call_guard<nb::gil_scoped_release>())
+      .def(
+          "simulate_conditional",
+          [](const Vinecop& self, const Eigen::MatrixXd& u_cond, bool qrng,
+             size_t num_threads, const std::vector<int>& seeds,
+             const std::optional<std::vector<size_t>>& conditioning_set)
+              -> Eigen::MatrixXd {
+            nb::gil_scoped_release release;
+            if (conditioning_set) {
+              return self.simulate_conditional(u_cond, *conditioning_set, qrng,
+                                               num_threads, seeds);
+            }
+            return self.simulate_conditional(u_cond, qrng, num_threads, seeds);
+          },
+          "u_cond"_a, "qrng"_a = false, "num_threads"_a = 1,
+          "seeds"_a = std::vector<int>(), nb::kw_only(),
+          "conditioning_set"_a = nb::none(), simulate_conditional_doc.c_str())
       // `u` is taken by value and moved: the implementation uses it as a
       // working buffer, and a const reference would force an n x d copy.
       // `u` is taken by value and moved: the implementation uses it as a

--- a/src/include/vinecop/class.hpp
+++ b/src/include/vinecop/class.hpp
@@ -286,6 +286,7 @@ the model.
   const std::string simulate_conditional_doc =
       std::string(vinecop_doc.simulate_conditional.doc_4args) +
       R"""(
+
 Notes
 -----
 ``conditioning_set`` names the variables to condition on, as 1-based indices,

--- a/tests/test_vinecop.py
+++ b/tests/test_vinecop.py
@@ -918,3 +918,36 @@ def test_simulate_conditional_rejects_inadmissible_set() -> None:
   cop, u = _cop_and_data()
   with pytest.raises(RuntimeError):
     cop.simulate_conditional(u[:10, :2], conditioning_set=[])
+
+
+def test_simulate_conditional_discrete_set_takes_a_left_limit_column() -> None:
+  # A discrete conditioning variable is described by two columns, its cdf and
+  # its left limit, so ``u_cond`` is wider than the conditioning set.
+  rng = np.random.default_rng(11)
+  d, n, m = 4, 600, 32
+
+  continuous = rng.standard_normal((n, d)) @ rng.standard_normal((d, d))
+  counts = np.floor(4.0 * pv.to_pseudo_obs(continuous[:, [d - 1]]))
+  data = np.column_stack([continuous[:, : d - 1], counts])
+
+  # Expanded layout: d columns, then a left-limit column per discrete variable.
+  ecdf = pv.to_pseudo_obs(data)
+  left = pv.to_pseudo_obs(np.column_stack([counts - 1.0]))
+  u = np.column_stack([ecdf, left])
+
+  var_types = ["c"] * (d - 1) + ["d"]
+  controls = pv.FitControlsVinecop()
+  controls.conditioning_set = [d]
+  cop = pv.Vinecop.from_data(u, var_types=var_types, controls=controls)
+  assert int(cop.structure.order[-1]) == d
+
+  u_cond = np.column_stack([u[:m, d - 1], u[:m, d]])
+  drawn = cop.simulate_conditional(u_cond, seeds=[1, 2, 3])
+
+  assert drawn.shape == (m, d)
+  # The conditioning column is reproduced, not resampled.
+  np.testing.assert_allclose(drawn[:, -1], u_cond[:, 0], rtol=1e-12)
+
+  # Dropping the left-limit column leaves the model under-specified.
+  with pytest.raises(RuntimeError):
+    cop.simulate_conditional(u_cond[:, :1], seeds=[1, 2, 3])

--- a/tests/test_vinecop.py
+++ b/tests/test_vinecop.py
@@ -864,3 +864,57 @@ def test_rosenblatt_conditioning_set_rejects_truncated_vine() -> None:
     cop.rosenblatt(u, conditioning_set=[1, 2])
   with pytest.raises(RuntimeError):
     cop.inverse_rosenblatt(u, conditioning_set=[1, 2])
+
+
+def _cop_conditioned_on(cs: list[int], d: int = 5, n: int = 400):
+  """A vine whose order tail is ``cs``, so ``cs`` is an admissible set."""
+  controls = pv.FitControlsVinecop()
+  controls.conditioning_set = cs
+  u = pv.to_pseudo_obs(random_data(d, n))
+  return pv.Vinecop.from_data(u, controls=controls), u
+
+
+def test_simulate_conditional_explicit_set_matches_implicit() -> None:
+  # Given in the tail's own order, the explicit form reproduces the implicit
+  # one exactly (vinecopulib#729).
+  cs = [2, 3]
+  cop, u = _cop_conditioned_on(cs)
+  tail = [int(v) for v in cop.structure.order][-2:]
+  u_cond = u[:20, [t - 1 for t in tail]]
+
+  implicit = cop.simulate_conditional(u_cond, seeds=[1, 2])
+  explicit = cop.simulate_conditional(
+    u_cond, seeds=[1, 2], conditioning_set=tail
+  )
+  np.testing.assert_array_equal(implicit, explicit)
+
+
+def test_simulate_conditional_explicit_set_column_mapping() -> None:
+  # The two forms map u_cond's columns differently: implicitly by the order
+  # tail, explicitly by the given set. Reversing the set must permute the
+  # columns it consumes, not be ignored.
+  cs = [2, 3]
+  cop, u = _cop_conditioned_on(cs)
+  tail = [int(v) for v in cop.structure.order][-2:]
+  u_cond = u[:20, [t - 1 for t in tail]]
+
+  forward = cop.simulate_conditional(u_cond, seeds=[3], conditioning_set=tail)
+  reversed_ = cop.simulate_conditional(
+    u_cond[:, ::-1], seeds=[3], conditioning_set=tail[::-1]
+  )
+  np.testing.assert_allclose(forward, reversed_, rtol=1e-10, atol=1e-10)
+
+
+def test_simulate_conditional_does_not_mutate_the_model() -> None:
+  cs = [2, 3]
+  cop, u = _cop_conditioned_on(cs)
+  tail = [int(v) for v in cop.structure.order][-2:]
+  order_before = [int(v) for v in cop.structure.order]
+  cop.simulate_conditional(u[:10, [t - 1 for t in tail]], conditioning_set=tail)
+  assert [int(v) for v in cop.structure.order] == order_before
+
+
+def test_simulate_conditional_rejects_inadmissible_set() -> None:
+  cop, u = _cop_and_data()
+  with pytest.raises(RuntimeError):
+    cop.simulate_conditional(u[:10, :2], conditioning_set=[])


### PR DESCRIPTION
Stacked on #255. Completes the conditioning surface from vinecopulib#729.

## What

`simulate_conditional` can name the variables to condition on, rather than
taking them from the tail of the vine order:

```python
x = cop.simulate_conditional(u_cond, conditioning_set=[2, 3])
```

`u_cond` is accepted in either discrete layout — **expanded** `(n, 2k)`, with
the left limits `F(x-)` of all `k` conditioning variables in a second block, or
**compact** `(n, k + k_d)`, carrying left limits only for the `k_d` discrete
ones. For continuous conditioning variables the two coincide at `(n, k)`.

Keyword-only, matching #255, and the model is not mutated — evaluation goes
through a reoriented view.

## The trap this pull request documents and tests

**The two forms map `u_cond`'s columns differently.**

- without the argument: column `i` is the `i`-th variable of the **order tail**;
- with it: column `i` is `conditioning_set[i]`.

So adding `conditioning_set=` to an existing call silently *permutes the
columns* unless the set is given in the tail's own order. Both the docstring and
`test_simulate_conditional_explicit_set_column_mapping` state it — the test
reverses both the set and the columns and asserts the result is unchanged, which
only holds if the mapping is by set position rather than by tail position.

## Tests

- given in the tail's order, the explicit form is **bit-identical** to the
  implicit one;
- reversing the set permutes the columns it consumes rather than being ignored;
- `structure.order` is unchanged after a keyword-form call;
- an inadmissible set raises `RuntimeError`.

`431 passed, 26 xfailed` locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)