### PR TITLE
feat(bicop)!: accept the discrete data layouts in from_data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@
 
 #### NEW FEATURES
 
+- `Bicop.from_data` accepts discrete data. It took a statically two-column matrix, so the `n x (2 + k)` and `n x 4` layouts a discrete pair needs could not be passed at all ([vinecopulib#729](https://github.com/vinecopulib/vinecopulib/pull/729)).
 - `Vinecop.simulate_conditional` accepts an explicit `conditioning_set` and both discrete `u_cond` layouts — expanded `(n, 2k)` and compact `(n, k + k_d)` ([vinecopulib#729](https://github.com/vinecopulib/vinecopulib/pull/729)). Note that the two forms map `u_cond`'s columns differently: implicitly by the vine's order tail, explicitly by the given set.
 - `Vinecop.rosenblatt` and `Vinecop.inverse_rosenblatt` accept an explicit `conditioning_set`, holding the named variables fixed instead of the ones at the tail of the vine order, and evaluating through a reoriented non-owning view rather than copying pair copulas ([vinecopulib#715](https://github.com/vinecopulib/vinecopulib/pull/715)). The argument is keyword-only, so `rosenblatt(u, 4)` still means `num_threads=4`.
 - `Bicop.simulate` draws one observation per parameter set: pass `parameters` (an `(n, p)` array) instead of `n`, whose row count then fixes the sample size ([vinecopulib#719](https://github.com/vinecopulib/vinecopulib/pull/719)). `parameters` is keyword-only, so the positional `simulate(n, qrng, seeds)` keeps its meaning, and rejects a 1-d array, which would otherwise be read as a single row. `num_threads` applies only to this form.

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -512,6 +512,44 @@ parameters; on ``Vinecop`` these accept an optional per-observation
 ``parameters`` matrix for evaluation off the fitted point.
 
 
+.. _concepts-discrete:
+
+Discrete data
+-------------
+
+Sklar's theorem does not identify a unique copula when a margin has
+atoms, so a discrete variable cannot be summarized by
+:math:`\hat F_j(x)` alone: the estimator also needs the left limit
+:math:`\hat F_j(x^-)`, the value the cdf takes just below the jump.
+Mark which variables are discrete with ``var_types`` — ``"c"`` for
+continuous, ``"d"`` for discrete, one entry per variable — and supply
+the extra column each discrete variable needs.
+
+There are two ways to lay those columns out, and every method taking
+``u`` accepts either:
+
+* **Expanded**, :math:`n \times 2d`: the :math:`d` cdf values, then
+  :math:`d` left-limit values. The left-limit column of a continuous
+  variable is simply equal to its cdf column.
+* **Compact**, :math:`n \times (d + k)`: the :math:`d` cdf values, then
+  one left-limit column per discrete variable, in variable order. With
+  :math:`k` discrete variables out of :math:`d`, this is the expanded
+  layout with the redundant continuous columns dropped.
+
+The two agree exactly — the compact form only omits columns that carry
+no information. For an all-continuous model :math:`k = 0` and both
+collapse to the familiar :math:`n \times d` matrix.
+
+The same rule applies pairwise to :class:`pyvinecopulib.core.Bicop`
+(:math:`n \times 4` expanded, :math:`n \times (2 + k)` compact) and to
+the conditioning values passed to
+:meth:`pyvinecopulib.core.Vinecop.simulate_conditional`, where a
+discrete conditioning variable likewise contributes two columns.
+
+The ``examples/04_discrete_variables.ipynb`` notebook works an example
+end to end, from raw counts to a fitted vine.
+
+
 .. _concepts-structure-selection:
 
 Structure selection

--- a/scripts/generate_docstring.py
+++ b/scripts/generate_docstring.py
@@ -687,6 +687,14 @@ def transform_docstring(docstring, cursor=None):
   return final_docstring
 
 
+#: Doxygen page name -> the Sphinx role that renders it on the Python site.
+#: Only pages actually referenced from a bound docstring need an entry; see
+#: the `@ref` handling in `process_comment`.
+_REF_TARGETS = {
+  "discrete": ":ref:`discrete data <concepts-discrete>`",
+}
+
+
 # TODO(jamiesnape): Refactor into multiple functions and unit test.
 def process_comment(comment, cursor=None):
   """
@@ -831,7 +839,16 @@ def process_comment(comment, cursor=None):
 
   s = re.sub(r"[@\\]details\s*", r"\n\n", s)
   s = re.sub(r"[@\\](?:brief|short)\s*", r"", s)
-  s = re.sub(r"[@\\]ref\s+", r"", s)
+
+  # Doxygen page references. Upstream's pages have no Python counterpart, so
+  # each one that reaches a bound docstring is mapped to the section of the
+  # Sphinx docs covering the same ground; anything unmapped degrades to its
+  # bare target rather than rendering as a broken link.
+  def _ref(match: re.Match) -> str:
+    target = match.group(1)
+    return _REF_TARGETS.get(target, target)
+
+  s = re.sub(r"[@\\]ref\s+(\w+)", _ref, s)
 
   for start_, end_ in (("code", "endcode"), ("verbatim", "endverbatim")):
     s = re.sub(

--- a/src/include/bicop/class.hpp
+++ b/src/include/bicop/class.hpp
@@ -34,7 +34,10 @@ inline Bicop bc_from_family(const BicopFamily& family, int rotation,
 }
 
 // Factory function to create a Bicop from data, controls, and variable types
-inline Bicop bc_from_data(const Eigen::Matrix<double, Eigen::Dynamic, 2>& data,
+// `data` is dynamically sized, not statically two-column: a discrete variable
+// needs a left-limit column, so the accepted shapes are `n x 2`, `n x (2 + k)`
+// and `n x 4` (vinecopulib#729).
+inline Bicop bc_from_data(const Eigen::MatrixXd& data,
                           const FitControlsBicop& controls = FitControlsBicop(),
                           const std::vector<std::string>& var_types = {"c",
                                                                        "c"}) {
@@ -287,18 +290,15 @@ Bicop
             if (parameters) return self.loglik(u, *parameters, num_threads);
             return self.loglik(u);
           },
-          "u"_a = Eigen::Matrix<double, Eigen::Dynamic, 2>(),
-          "parameters"_a = nb::none(), "num_threads"_a = static_cast<size_t>(1),
-          loglik_doc.c_str(), nb::call_guard<nb::gil_scoped_release>())
+          "u"_a = Eigen::MatrixXd(), "parameters"_a = nb::none(),
+          "num_threads"_a = static_cast<size_t>(1), loglik_doc.c_str(),
+          nb::call_guard<nb::gil_scoped_release>())
       .def_prop_ro("nobs", &Bicop::get_nobs, bicop_doc.get_nobs.doc)
-      .def("aic", &Bicop::aic,
-           "u"_a = Eigen::Matrix<double, Eigen::Dynamic, 2>(),
-           bicop_doc.aic.doc, nb::call_guard<nb::gil_scoped_release>())
-      .def("bic", &Bicop::bic,
-           "u"_a = Eigen::Matrix<double, Eigen::Dynamic, 2>(),
-           bicop_doc.bic.doc, nb::call_guard<nb::gil_scoped_release>())
-      .def("mbic", &Bicop::mbic,
-           "u"_a = Eigen::Matrix<double, Eigen::Dynamic, 2>(), "psi0"_a = 0.9,
+      .def("aic", &Bicop::aic, "u"_a = Eigen::MatrixXd(), bicop_doc.aic.doc,
+           nb::call_guard<nb::gil_scoped_release>())
+      .def("bic", &Bicop::bic, "u"_a = Eigen::MatrixXd(), bicop_doc.bic.doc,
+           nb::call_guard<nb::gil_scoped_release>())
+      .def("mbic", &Bicop::mbic, "u"_a = Eigen::MatrixXd(), "psi0"_a = 0.9,
            bicop_doc.mbic.doc, nb::call_guard<nb::gil_scoped_release>())
       .def(
           "__repr__",

--- a/tests/test_bicop.py
+++ b/tests/test_bicop.py
@@ -796,3 +796,57 @@ def test_simulate_positional_signature_is_unchanged() -> None:
   # meaning what it meant.
   cop = pv.Bicop.from_family(pv.families.gaussian, parameters=np.array([[0.5]]))
   assert cop.simulate(12, False, [1, 2]).shape == (12, 2)
+
+
+def _discrete_pair(n: int = 500, seed: int = 3):
+  """A (continuous, discrete) pair as F(x) and the discrete left limit."""
+  rng = np.random.default_rng(seed)
+  z = rng.normal(size=(n, 2))
+  u1 = pv.to_pseudo_obs(z[:, [0]])[:, 0]
+  counts = np.floor(np.abs(z[:, 1]) * 3).astype(int)
+  hi = (counts + 1) / (counts.max() + 2)
+  lo = counts / (counts.max() + 2)
+  return u1, hi, lo
+
+
+def test_from_data_accepts_the_compact_discrete_layout() -> None:
+  # `from_data` took a statically two-column matrix, so a discrete pair — which
+  # needs a left-limit column — could not be passed at all (vinecopulib#729).
+  u1, hi, lo = _discrete_pair()
+  compact = np.column_stack([u1, hi, lo])
+  cop = pv.Bicop.from_data(compact, var_types=["c", "d"])
+  assert cop.var_types == ["c", "d"]
+
+
+def test_from_data_discrete_layouts_agree() -> None:
+  # Expanded (n, 4) and compact (n, 2 + k) describe the same data.
+  u1, hi, lo = _discrete_pair()
+  compact = np.column_stack([u1, hi, lo])
+  expanded = np.column_stack([u1, hi, u1, lo])
+
+  controls = pv.FitControlsBicop(family_set=[pv.families.gaussian])
+  a = pv.Bicop.from_data(compact, controls=controls, var_types=["c", "d"])
+  b = pv.Bicop.from_data(expanded, controls=controls, var_types=["c", "d"])
+  np.testing.assert_allclose(a.parameters, b.parameters, rtol=1e-12)
+
+
+def test_from_data_still_accepts_plain_continuous_input() -> None:
+  # Widening the accepted type must not change how ordinary input converts.
+  # nanobind's ndarray caster takes arrays, not sequences, on every
+  # Eigen-typed argument in this package; `from_data` is no exception.
+  rng = np.random.default_rng(0)
+  u = pv.to_pseudo_obs(rng.normal(size=(200, 2)))
+  assert isinstance(pv.Bicop.from_data(u), pv.Bicop)
+  assert isinstance(pv.Bicop.from_data(np.asarray(u, order="C")), pv.Bicop)
+  with pytest.raises(TypeError):
+    pv.Bicop.from_data(u.tolist())
+
+
+def test_loglik_rejects_a_wrong_column_count() -> None:
+  # vinecopulib#729 made `loglik` validate the column count instead of
+  # reading past the data.
+  rng = np.random.default_rng(1)
+  u = pv.to_pseudo_obs(rng.normal(size=(100, 2)))
+  cop = pv.Bicop.from_data(u)
+  with pytest.raises(RuntimeError):
+    cop.loglik(np.column_stack([u, u[:, [0]], u[:, [1]], u[:, [0]]]))


### PR DESCRIPTION
Stacked on #256.

## Why

`Bicop.from_data` **could not be handed discrete data at all**. `bc_from_data`
took an `Eigen::Matrix<double, Dynamic, 2>` — a *statically* two-column type —
while a discrete variable needs a left-limit column, giving `n × (2 + k)` or
`n × 4` (vinecopulib#729). The shape was rejected before it ever reached the
C++ constructor, which has always supported it.

```python
compact = np.column_stack([u1, hi, lo])          # n x 3
cop = pv.Bicop.from_data(compact, var_types=["c", "d"])   # TypeError before
```

The same statically-sized type appeared on the empty defaults of `loglik`,
`aic`, `bic` and `mbic`; all five sites now say `Eigen::MatrixXd`.

## The compatibility question, checked rather than assumed

Widening the accepted Eigen type changes which Python objects convert, so the
risk was that a 2-column *list of lists* stopped working. It did not — because
it never worked:

```
list REJECTED : Bicop.pdf (Eigen::MatrixXd, pre-existing)
list REJECTED : Vinecop.from_data (Eigen::MatrixXd, pre-existing)
list REJECTED : Bicop.from_data (widened here)
```

nanobind's ndarray caster takes arrays, not sequences, on **every** Eigen-typed
argument in this package. The widening therefore makes `from_data` *consistent*
with the rest of the surface rather than narrowing it. `test_from_data_still_accepts_plain_continuous_input`
pins all three facts (ndarray works, C-order works, list raises), so a future
caster change is caught rather than discovered.

Marked `!` regardless: the accepted argument type genuinely changed.

## Tests

- the compact `(n, 2 + k)` layout is accepted and `var_types` round-trips;
- compact and expanded `(n, 4)` fit **identical parameters**;
- ordinary continuous input is unaffected;
- `loglik` raises on a wrong column count, which #729 made a validation error
  instead of a read past the data.

`435 passed, 26 xfailed` locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)