### PR TITLE
docs(concepts): correct what the 1.0.0 pin changed

### DIFF
--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -276,12 +276,21 @@ fit-time search space.
 
 Parameter ranges below are the conventional textbook ones; the
 exact bounds the C++ library enforces are visible via
-:meth:`pyvinecopulib.core.Bicop.get_parameters_lower_bounds` and
-:meth:`pyvinecopulib.core.Bicop.get_parameters_upper_bounds`. The
-"Kendall's :math:`\tau`" column lists the closed-form mapping where
-one exists; otherwise :meth:`pyvinecopulib.core.Bicop.parameters_to_tau`
-(and its inverse :meth:`~pyvinecopulib.core.Bicop.tau_to_parameters`)
-implement the numerical conversion.
+:attr:`pyvinecopulib.core.Bicop.parameters_lower_bounds` and
+:attr:`pyvinecopulib.core.Bicop.parameters_upper_bounds`. The
+"Kendall's :math:`\tau`" column says how
+:meth:`pyvinecopulib.core.Bicop.parameters_to_tau` obtains the value:
+in closed form, or by quadrature.
+
+:meth:`~pyvinecopulib.core.Bicop.parameters_to_tau` is available for every
+family. Its inverse :meth:`~pyvinecopulib.core.Bicop.tau_to_parameters` is
+not: it needs :math:`\tau` to determine the parameters completely, which
+holds only for the one-parameter families ``indep``, ``gaussian``,
+``clayton``, ``gumbel``, ``frank`` and ``joe``. In particular it raises for
+``student``, even though ``student`` belongs to
+:data:`pyvinecopulib.families.itau` — that group means "fittable by
+inverting :math:`\tau`", not "invertible here", because :math:`\tau` pins
+the correlation and leaves the degrees of freedom free.
 
 .. list-table::
    :header-rows: 1
@@ -366,7 +375,7 @@ implement the numerical conversion.
      - :math:`\theta \ge 1`, :math:`\delta \ge 1`
      - 0° / 90° / 180° / 270°
      - upper
-     - closed form
+     - by quadrature
    * - BB7
      - :data:`pyvinecopulib.families.bb7`
      - Arch. (2-par)
@@ -374,7 +383,7 @@ implement the numerical conversion.
      - :math:`\theta \ge 1`, :math:`\delta > 0`
      - 0° / 90° / 180° / 270°
      - lower + upper
-     - closed form
+     - by quadrature
    * - BB8
      - :data:`pyvinecopulib.families.bb8`
      - Arch. (2-par)
@@ -382,7 +391,7 @@ implement the numerical conversion.
      - :math:`\theta \ge 1`, :math:`\delta \in (0, 1]`
      - 0° / 90° / 180° / 270°
      - upper
-     - closed form
+     - by quadrature
    * - Tawn
      - :data:`pyvinecopulib.families.tawn`
      - extreme-value
@@ -390,7 +399,7 @@ implement the numerical conversion.
      - bounded; see C++ bounds
      - 0° / 90° / 180° / 270°
      - upper (asymmetric)
-     - via Pickands :math:`A`
+     - by quadrature
    * - TLL
      - :data:`pyvinecopulib.families.tll`
      - nonparametric
@@ -549,6 +558,55 @@ discrete conditioning variable likewise contributes two columns.
 The ``examples/04_discrete_variables.ipynb`` notebook works an example
 end to end, from raw counts to a fitted vine.
 
+Two arguments elsewhere in the API are consequences of the same
+non-uniqueness, and both change what you get rather than only how fast
+you get it:
+
+* ``randomize_discrete`` (on
+  :meth:`pyvinecopulib.core.Vinecop.rosenblatt`, default ``True``)
+  decides what the transform returns at an atom. The conditional
+  distribution there is an interval, not a point, so the transform draws
+  uniformly within :math:`[F(x^-), F(x)]`. That is what makes the output
+  genuinely uniform — the randomized transform is the one whose
+  distributional statement holds — but it also makes the call
+  non-deterministic. Pass ``seeds`` to reproduce it, or
+  ``randomize_discrete=False`` to take the upper endpoint instead and
+  accept output that is not uniform.
+* ``step_wise`` (on the ``Vinecop`` score family: ``scores``,
+  ``gradient``, ``hessian``, ``scores_cov``) selects which likelihood is
+  differentiated. ``True`` differentiates the step-wise (sequential,
+  tree-by-tree) estimator that was actually fitted; ``False``
+  differentiates the joint likelihood. They answer different questions:
+  the step-wise gradient vanishes at the fitted model by construction,
+  the joint one does not. Sandwich standard errors for a sequentially
+  fitted vine want the step-wise form.
+
+
+.. _concepts-serialization:
+
+Saving and loading models
+-------------------------
+
+``Bicop``, ``Vinecop`` and ``RVineStructure`` all serialize the same
+way. ``to_file`` / ``from_file`` write and read a file; ``to_json`` /
+``from_json`` do the same through a string:
+
+.. code-block:: python
+
+   vine.to_file("model.json")             # JSON text
+   vine.to_file("model.cbor")             # binary CBOR
+   reloaded = pv.Vinecop.from_file("model.cbor")
+
+The format follows the filename: a name ending in ``.cbor`` selects
+binary `CBOR <https://cbor.io>`_, anything else JSON. CBOR is smaller
+and faster to parse and is the better choice for large vines; JSON stays
+the default because it is readable and diffable.
+
+All three classes also pickle, which serializes through the JSON form,
+so a fitted model round-trips through anything that speaks pickle
+(``copy.deepcopy``, ``joblib``, a multiprocessing queue). The
+:mod:`pyvinecopulib.sklearn` estimators pickle as ordinary estimators.
+
 
 .. _concepts-structure-selection:
 
@@ -609,8 +667,19 @@ variables' distribution conditional on that point (implemented as a Rosenblatt
 transform of the conditioning variables followed by an inverse Rosenblatt
 transform, so discrete conditioning variables are supported too).
 
-Because conditioning acts on the order *tail*, it is most efficient when the
-conditioning set already sits there. Two tools arrange that:
+The conditioning variables can also be named explicitly, with
+``simulate_conditional(u_cond, conditioning_set=[...])`` — 1-based indices.
+Note that the two forms map ``u_cond``'s columns differently: without the
+argument, column ``i`` is the ``i``-th variable of the order tail; with it,
+column ``i`` is ``conditioning_set[i]``. The same argument is available on
+:meth:`pyvinecopulib.core.Vinecop.rosenblatt` and
+:meth:`~pyvinecopulib.core.Vinecop.inverse_rosenblatt`, which then hold those
+variables fixed rather than the order tail. In every case the vine is
+evaluated through a reoriented view and the model is left unchanged.
+
+Not every set is admissible as a sampling-order tail; when it is not, a
+``RuntimeError`` says so. Conditioning is cheapest when the set already sits at
+the tail, and two tools arrange that:
 
 * :attr:`pyvinecopulib.core.FitControlsVinecop.conditioning_set` — select a vine
   whose order ends with a chosen set of variables (their own optimal sub-vine is
@@ -711,6 +780,18 @@ Nagler & Czado, 2025), which replaces the marginal CDF derivatives in
 user — pass ``var_types=["d", ...]`` to
 :meth:`pyvinecopulib.core.Vinecop.from_data` or set
 ``type="d"`` on :class:`pyvinecopulib.utils.Kde1d`).
+
+A discrete variable needs its left limit :math:`F(x^-)` alongside
+:math:`F(x)`, and there are two ways to supply them. The **expanded** layout is
+``(n, 2d)``: the first :math:`d` columns are :math:`F(x)`, the next :math:`d`
+are :math:`F(x^-)` for the same variables in the same order, with continuous
+columns simply repeated. Its shape does not depend on ``var_types``, which is
+what makes it the easier convention to write against. The **compact** layout is
+``(n, d + k)``: the same first :math:`d` columns, then left limits for the
+:math:`k` discrete variables only, in the order they appear. Both are accepted
+wherever discrete data is; for an all-continuous model they coincide at
+``(n, d)``. The same applies per pair to
+:meth:`pyvinecopulib.core.Bicop.from_data`, with :math:`d = 2`.
 
 
 .. _concepts-extending:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -388,7 +388,7 @@ def _stage_repo_files(docs_dir, repo_root):
   """Symlink (or copy on Windows) repo-root files into the docs source dir."""
   import shutil
 
-  to_stage = ["README.md", "examples", "CHANGELOG.md", "CONTRIBUTING.md"]
+  to_stage = ["README.md", "examples", "CHANGELOG.md"]
   for name in to_stage:
     src = os.path.join(repo_root, name)
     dst = os.path.join(docs_dir, name)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,11 +23,11 @@ pyvinecopulib
    :maxdepth: 2
 
    README
-   features
    concepts
    examples
+   features
+   migrating-to-1.0
    CHANGELOG
-   CONTRIBUTING
 
 .. include:: _README_inlined.md
       :parser: myst_parser.sphinx_

--- a/docs/migrating-to-1.0.md
+++ b/docs/migrating-to-1.0.md
@@ -1,0 +1,65 @@
+# Migrating to 1.0.0
+
+Most code needs no changes. This page lists everything in 1.0.0 that can
+make working code behave differently, in the order you are likely to hit it.
+
+If you are coming from the C++ library, note that
+[vinecopulib's own migration guide](https://github.com/vinecopulib/vinecopulib/blob/main/docs/migrating-to-1.0.md)
+is mostly **not** about Python. Its central warning — a constructor argument
+inserted in the middle, which compiles silently against old positional calls —
+does not reach here, because every alternative constructor in this package is a
+named factory (`Bicop.from_family`, `Vinecop.from_data`, …) rather than an
+overload. The two items below are the parts that do carry over.
+
+## Model selection now defaults to AIC
+
+`FitControlsBicop` and `FitControlsVinecop` default `selection_criterion` to
+`"aic"`. They previously defaulted to `"bic"` in Python while C++ and R already
+used `"aic"`, so the same knob selected different models depending on which
+language you called from.
+
+This changes which families and structures get selected. Nothing raises; the
+fitted model is simply different, usually slightly less parsimonious. To keep
+the previous behavior, say so explicitly:
+
+```python
+controls = pv.FitControlsVinecop(selection_criterion="bic")
+```
+
+Saved models are unaffected — the criterion is a fit-time setting, not part of
+a serialized model.
+
+## Some arguments are keyword-only
+
+`parameters` on `Bicop.simulate`, and `conditioning_set` on
+`Vinecop.rosenblatt` / `inverse_rosenblatt` / `simulate_conditional`, are
+keyword-only. This is what keeps the long-standing positional forms meaning
+what they always meant: `rosenblatt(u, 4)` is still `num_threads=4`, and
+`simulate(1000, True)` is still `n=1000, qrng=True`.
+
+You only need to change code that was already passing these by keyword, which
+is to say: none.
+
+## Top-level aliases still work, and still warn
+
+`pyvinecopulib.gaussian`, `pyvinecopulib.Kde1d`, `pyvinecopulib.wdm` and the
+other names moved into subpackages in 0.8.0 continue to resolve at the top
+level, emitting a `DeprecationWarning` that names the canonical path. They are
+**not** removed in 1.0.0 — that release breaks enough on its own — but they are
+scheduled for removal in 2.0. Move to the subpackage imports now:
+
+```python
+from pyvinecopulib.families import gaussian
+from pyvinecopulib.utils import Kde1d, wdm
+```
+
+The eight core classes (`Bicop`, `Vinecop`, the three structures, the two
+fit-controls classes, `BicopFamily`) and `to_pseudo_obs` stay at the top level
+indefinitely.
+
+## What did not change
+
+- Serialized models. JSON and CBOR files written by 0.8.x load unchanged.
+- Every evaluation signature other than the keyword-only arguments above.
+- `pyvinecopulib.sklearn` and `pyvinecopulib.torch`, which are on their own
+  release cadence; see the changelog for those.


### PR DESCRIPTION
Stacked on #259.

## Why

Three statements on the concepts page became wrong with the 1.0.0 pin, and one was already wrong.

**The parameter bounds are documented as C++ names.** The page tells users to call `Bicop.get_parameters_lower_bounds()` / `..._upper_bounds()`; Python exposes *properties*, `parameters_lower_bounds` / `parameters_upper_bounds`. Those references only resolved because `nitpick_ignore_regex` silences them — the entry stays, because it is also needed for the `BicopFamily` docstring upstream generates, but the hand-written prose no longer relies on it.

**The Kendall's tau column is wrong for four families.** It claims a closed form for `bb6`, `bb7` and `bb8`, and "via Pickands A" for `tawn`. All four are computed by quadrature — and vinecopulib#713 fixed four numerical defects in exactly those integrands, the worst returning ~`1e-11` where the true value was `0.33`. The column now says how the value is obtained.

The surrounding text also now says where the *inverse* map exists at all: `tau_to_parameters` needs tau to determine the parameters completely, so it raises for `student` — even though `student` is in `families.itau`, because that group means "fittable by inverting tau", not "invertible here". That is a trap a reader would otherwise walk into from this very page.

**Conditional sampling is described as order-tail-only.** It now also takes an explicit set, on `simulate_conditional` and both Rosenblatt transforms, with the column-mapping difference between the two forms spelled out.

**The discrete section never named the layouts.** It now describes expanded `(n, 2d)` and compact `(n, d + k)`, and says why expanded is the easier convention to write against: its shape does not depend on `var_types`.

## Testing

`make docs` (nitpicky, `-W`) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
