### PR TITLE
fix(sklearn)!: put the mixin first so the estimators are what they claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 - `TorchBicop.from_data` now dispatches on `controls=FitControlsTorchBicop(...)` (#217). Callers who passed `grid_size`, `mult`, or `grid_type` as keyword arguments must move them onto the dataclass. `cache_integrals`, `device`, and `dtype` remain direct kwargs on `from_data`.
 - `TorchBicop.sample(num_sample, seed, is_sobol)` renamed to `TorchBicop.simulate(n, qrng=False, seeds=[])` for parity with `pv.Bicop.simulate` (#216).
 - Remove `TorchBicop`'s `log_pdf` method. The vine `pdf` cascade now accumulates a product of per-edge `pdf` (rather than a log-sum-exp), so the pair-level log-density convenience method is no longer needed; it was never part of the `BicopLike` contract. Use `TorchBicop.pdf(u).log()` if you need a log density.
+- `VineDensity` and `VineRegressor` put their scikit-learn mixin before `VineBase`, so `is_regressor` / `is_density_estimator` are now `True` and meta-estimators such as `StackingRegressor` accept them; previously they were rejected as "not a regressor" (#263).
+- `VineRegressor.predict` keeps the sample axis for a one-row `X`: it returns shape `(1,)` (or `(1, k)` with quantiles) instead of collapsing to a 0-d scalar (#263).
 - `FitControlsBicop` and `FitControlsVinecop` default `selection_criterion` to `"aic"` instead of `"bic"`, matching the C++ and R defaults; the same knob now selects the same model from all three languages. Pass `selection_criterion="bic"` explicitly to keep the previous selection (#251).
 
 ### New features in `pyvinecopulib`
@@ -70,6 +72,7 @@
 
 ### Bug fixes in `pyvinecopulib`
 
+- Reject non-finite `X` / `y` in the `pyvinecopulib.sklearn` estimators instead of passing them to `Kde1d`, which reads NaN as a segmentation fault (#263).
 - Port the `integrate_2d` marginal-renormalization fix to the torch backend (`InterpolationGrid2D.integrate_2d` and `integrate_2d_batched`) so `TorchBicop.cdf` enforces ``C(1, u_2) = u_2`` exactly, matching the post-vinecopulib#667 C++ CDF to machine precision on the on-the-fly path ([vinecopulib#667](https://github.com/vinecopulib/vinecopulib/pull/667)).
 - Declare `BicopFamily` enum members as class attributes in the generated type stubs so the documented `pv.BicopFamily.clayton` access pattern passes static type checking (`ty` / pyright / mypy), not only the module-level constants (#223).
 

--- a/src/pyvinecopulib/sklearn/_base.py
+++ b/src/pyvinecopulib/sklearn/_base.py
@@ -1,10 +1,16 @@
+import warnings
 from numbers import Integral
 
 import numpy as np
 import pandas as pd
 from sklearn.base import BaseEstimator
+from sklearn.exceptions import DataConversionWarning
 from sklearn.utils._param_validation import Interval
-from sklearn.utils.validation import check_is_fitted, check_random_state
+from sklearn.utils.validation import (
+  assert_all_finite,
+  check_is_fitted,
+  check_random_state,
+)
 
 import pyvinecopulib as pv
 
@@ -199,6 +205,17 @@ class VineBase(BaseEstimator):
       raise ValueError("X must be a numpy array or pandas DataFrame")
     if y is not None:
       y = np.asarray(y)
+      # A column vector is the shape callers reach for after slicing a
+      # DataFrame; sklearn's convention is to ravel it and say so.
+      if y.ndim == 2 and y.shape[1] == 1:
+        warnings.warn(
+          "A column-vector y was passed when a 1d array was expected. "
+          "Please change the shape of y to (n_samples,), for example using "
+          "ravel().",
+          DataConversionWarning,
+          stacklevel=2,
+        )
+        y = y.ravel()
       if X.shape[0] != y.shape[0]:
         raise ValueError("X and y must have the same number of samples.")
 
@@ -256,7 +273,11 @@ class VineBase(BaseEstimator):
           raise ValueError("X has wrong number of features.")
       X_arr = X
 
+    # The marginal estimator is C++ and reads NaN / inf as a segmentation
+    # fault rather than an error, so nothing downstream can report this.
+    assert_all_finite(X_arr, input_name="X")
     if y is not None:
+      assert_all_finite(y, input_name="y")
       return X_arr, y
     return X_arr
 

--- a/src/pyvinecopulib/sklearn/density.py
+++ b/src/pyvinecopulib/sklearn/density.py
@@ -14,7 +14,7 @@ from ._base import (
 )
 
 
-class VineDensity(VineBase, DensityMixin):
+class VineDensity(DensityMixin, VineBase):
   def __init__(
     self,
     backend=None,

--- a/src/pyvinecopulib/sklearn/regressor.py
+++ b/src/pyvinecopulib/sklearn/regressor.py
@@ -11,7 +11,7 @@ from ._base import (
 )
 
 
-class VineRegressor(VineBase, RegressorMixin):
+class VineRegressor(RegressorMixin, VineBase):
   # Inherits VineBase._parameter_constraints; extend with regressor knobs.
   _parameter_constraints: dict = {
     **VineBase._parameter_constraints,
@@ -96,7 +96,9 @@ class VineRegressor(VineBase, RegressorMixin):
     """
     self._validate_params()
     if y is None:
-      raise ValueError("VineRegressor.fit requires y.")
+      raise ValueError(
+        "VineRegressor requires y to be passed, but the target y is None"
+      )
     X, y = self._validate_input(X, y, reset=True)
     self._resolve_runtime_state()
     if self.quantiles is None and not self.mean:
@@ -307,7 +309,9 @@ class VineRegressor(VineBase, RegressorMixin):
         ]
         y_pred[start:end, col : col + len(quantiles)] = np.vstack(batch_preds)
 
-    return y_pred.squeeze()
+    # Drop the output axis for a single output, never the sample axis: a bare
+    # `squeeze()` turns a one-row prediction into a scalar.
+    return y_pred[:, 0] if y_pred.shape[1] == 1 else y_pred
 
   def predict(self, X):
     """Predicts the conditional mean and/or quantiles of ``Y`` given ``X``.

--- a/tests/test_sklearn_base.py
+++ b/tests/test_sklearn_base.py
@@ -10,7 +10,9 @@ pytest.importorskip("pandas")
 
 import pandas as pd  # noqa: E402
 
-from pyvinecopulib.sklearn import VineDensity  # noqa: E402
+from sklearn.exceptions import DataConversionWarning  # noqa: E402
+
+from pyvinecopulib.sklearn import VineDensity, VineRegressor  # noqa: E402
 from pyvinecopulib.sklearn._base import expand_factors  # noqa: E402
 
 
@@ -244,3 +246,31 @@ def test_vinebase_pdf_samples_unified_method(
 
   assert isinstance(copula_joint, np.ndarray)
   assert copula_joint.shape == (20,)
+
+
+def test_non_finite_input_raises_rather_than_crashing() -> None:
+  # The marginal estimator is C++ and reads NaN as a segmentation fault, so
+  # the guard has to be on this side of the boundary.
+  rng = np.random.default_rng(0)
+  X = rng.normal(size=(60, 3))
+  y = X @ np.array([1.0, 2.0, -1.0])
+
+  bad_X = X.copy()
+  bad_X[0, 0] = np.nan
+  with pytest.raises(ValueError, match="NaN"):
+    VineDensity().fit(bad_X)
+
+  bad_y = y.copy()
+  bad_y[3] = np.inf
+  with pytest.raises(ValueError, match="infinity|inf"):
+    VineRegressor().fit(X, bad_y)
+
+
+def test_column_vector_y_is_raveled_with_a_warning() -> None:
+  rng = np.random.default_rng(1)
+  X = rng.normal(size=(60, 3))
+  y = (X @ np.array([1.0, 2.0, -1.0])).reshape(-1, 1)
+
+  with pytest.warns(DataConversionWarning):
+    model = VineRegressor().fit(X, y)
+  assert model.predict(X[:4]).shape == (4,)

--- a/tests/test_sklearn_check_estimator.py
+++ b/tests/test_sklearn_check_estimator.py
@@ -50,7 +50,6 @@ _GENUINE_OPT_OUTS = {
   "check_fit2d_1sample": "Kde1d requires >= 2 samples to estimate a bandwidth",
   "check_fit1d": "vines require 2-D U-scale data",
   "check_fit2d_predict1d": "predict requires 2-D inputs",
-  "check_estimators_nan_inf": "NaN inputs not supported (documented)",
   "check_complex_data": "complex inputs not supported",
   "check_estimators_dtypes": "internal float64 promotion is intentional",
   "check_dtype_object": "internal float64 promotion is intentional",
@@ -60,10 +59,6 @@ _GENUINE_OPT_OUTS = {
   "check_n_features_in_after_fitting": (
     "TODO: n_features_in_ is set, but the sklearn check inspects "
     "the post-fit error path on wrong-shape input"
-  ),
-  "check_mixin_order": (
-    "TODO: swap to (DensityMixin, VineBase) / (RegressorMixin, VineBase) — "
-    "sklearn 1.8 enforces Mixin-before-BaseEstimator order"
   ),
   "check_pipeline_consistency": (
     "density score is mean log-likelihood (negative); standard "

--- a/tests/test_sklearn_regressor.py
+++ b/tests/test_sklearn_regressor.py
@@ -210,3 +210,37 @@ def test_copula_marginal_density_single_covariate(regression_setup):
 
   log_c = reg._copula_marginal_density(X_test[:20, :1], n_grid=200, log=True)
   assert np.allclose(log_c, np.log(c_x))
+
+
+def test_vine_regressor_is_a_regressor_to_sklearn() -> None:
+  # `RegressorMixin` has to precede `VineBase` in the MRO, or
+  # `BaseEstimator.__sklearn_tags__` -- which does not call `super()` -- wins
+  # and the estimator type is never set. Meta-estimators check this tag before
+  # they will accept an estimator at all.
+  from sklearn.base import is_regressor
+  from sklearn.ensemble import StackingRegressor
+
+  assert is_regressor(VineRegressor())
+
+  rng = np.random.default_rng(0)
+  X = rng.normal(size=(80, 3))
+  y = X @ np.array([1.0, 2.0, -1.0]) + 0.1 * rng.normal(size=80)
+  stacked = StackingRegressor(estimators=[("v", VineRegressor())], cv=2)
+  assert stacked.fit(X, y).predict(X[:5]).shape == (5,)
+
+
+def test_vine_regressor_predict_keeps_the_sample_axis() -> None:
+  # Only the output axis collapses for a single output. A one-row X used to
+  # come back as a 0-d scalar, so any caller predicting row by row got a
+  # different rank than the same call on two rows.
+  rng = np.random.default_rng(1)
+  X = rng.normal(size=(80, 3))
+  y = X @ np.array([1.0, 2.0, -1.0]) + 0.1 * rng.normal(size=80)
+
+  mean_only = VineRegressor().fit(X, y)
+  assert mean_only.predict(X[:1]).shape == (1,)
+  assert mean_only.predict(X[:4]).shape == (4,)
+
+  multi = VineRegressor(quantiles=[0.25, 0.75]).fit(X, y)
+  assert multi.predict(X[:1]).shape == (1, 3)
+  assert multi.predict(X[:4]).shape == (4, 3)


### PR DESCRIPTION
## Why

`is_regressor(VineRegressor())` was `False`, and `VineDensity` was likewise not a density estimator to scikit-learn. `RegressorMixin` / `DensityMixin` sat *after* `VineBase` in the MRO, so `BaseEstimator.__sklearn_tags__` — which does not call `super()` — won, and the estimator type was never set. Meta-estimators check that tag before they will accept an estimator at all:

```python
StackingRegressor(estimators=[("v", VineRegressor())], cv=2).fit(X, y)
# ValueError: The estimator VineRegressor should be a regressor.
```

The gap was already known — `check_mixin_order` was in the opt-out list with a `TODO`. Shipping a 1.0.0 that advertises scikit-learn compatibility with this broken is not defensible.

## What changed

Swapped the bases. That also turns on the sklearn checks that were being skipped for a non-regressor, and two of them found real bugs:

**`fit` segfaulted on non-finite input.** `Kde1d` is C++ and reads NaN as a segmentation fault rather than an error, so `check_supervised_y_no_nan` took the interpreter down. `_validate_input` now rejects non-finite `X` and `y` up front with sklearn's own message. That retires the `check_estimators_nan_inf` opt-out, whose stated reason ("NaN inputs not supported") described the crash rather than a decision.

**`predict` dropped the sample axis for a single row.** `y_pred.squeeze()` collapses every length-1 axis, so predicting one observation returned a 0-d scalar instead of `(1,)`, and `(3,)` instead of `(1, 3)` with quantiles — anyone predicting row by row got a different rank than the same call on two rows. Only the output axis should collapse.

Also accept a column-vector `y` with `DataConversionWarning` and a ravel, which is the shape you get from slicing a DataFrame.

## Testing

`tests/test_sklearn_*.py`: 144 passed, 25 xfailed. Two opt-outs removed (`check_mixin_order`, `check_estimators_nan_inf`); no new ones added. New regression tests cover `is_regressor`, a `StackingRegressor` round-trip, the non-finite guard, the column-vector warning, and the predict shape at n=1 and n=4 for both single and multi-output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
