### PR TITLE
fix(torch): keep the batched cache out of state_dict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
 
 ### Bug fixes in `pyvinecopulib`
 
+- Keep `TorchVinecop`'s batched cache out of `state_dict()`, so a checkpoint taken after a `batched=True` call no longer carries derived buffers that `load_state_dict` then rejects on a fresh model (#264).
 - Reject non-finite `X` / `y` in the `pyvinecopulib.sklearn` estimators instead of passing them to `Kde1d`, which reads NaN as a segmentation fault (#263).
 - Port the `integrate_2d` marginal-renormalization fix to the torch backend (`InterpolationGrid2D.integrate_2d` and `integrate_2d_batched`) so `TorchBicop.cdf` enforces ``C(1, u_2) = u_2`` exactly, matching the post-vinecopulib#667 C++ CDF to machine precision on the on-the-fly path ([vinecopulib#667](https://github.com/vinecopulib/vinecopulib/pull/667)).
 - Declare `BicopFamily` enum members as class attributes in the generated type stubs so the documented `pv.BicopFamily.clayton` access pattern passes static type checking (`ty` / pyright / mypy), not only the module-level constants (#223).

--- a/src/pyvinecopulib/core/vinecop_base.py
+++ b/src/pyvinecopulib/core/vinecop_base.py
@@ -256,7 +256,12 @@ class VinecopBase(VinecopLike[ArrayT], ABC):
         The memoized :meth:`_build_batched` result.
     """
     if self._batched is None:
-      self._batched = self._build_batched()
+      # Bypass any framework `__setattr__`: on the torch subclass this value
+      # is an `nn.Module`, and a normal assignment would register it as a
+      # child, so a derived cache would leak into `state_dict()` and a
+      # checkpoint taken after a batched call would not load into a fresh
+      # model. It is a memo of the pair copulas, not part of the model.
+      object.__setattr__(self, "_batched", self._build_batched())
     return self._batched
 
   def _eval_context(self):

--- a/tests/test_torch_vinecop.py
+++ b/tests/test_torch_vinecop.py
@@ -629,3 +629,29 @@ def test_simulate_conditional_requires_row_per_sample() -> None:
   x = torch.zeros(4, 1, dtype=torch.float64)
   with pytest.raises(ValueError, match="one covariate row per sample"):
     bc.simulate(10, x=x)
+
+
+def test_batched_cache_stays_out_of_the_state_dict() -> None:
+  # The batched state is a memo derived from the pair copulas, not part of
+  # the model. Registering it as a child module would put derived buffers in
+  # every checkpoint taken after a batched call, and `load_state_dict` on a
+  # fresh model would then reject them as unexpected keys.
+  rng = np.random.default_rng(0)
+  d = 4
+  u = pv.to_pseudo_obs(
+    rng.standard_normal((400, d)) @ rng.standard_normal((d, d))
+  )
+  cpp = pv.Vinecop.from_data(
+    u, controls=pv.FitControlsVinecop(family_set=[pv.families.tll])
+  )
+  vine = TorchVinecop.from_vinecop(cpp)
+  data = torch.as_tensor(u)
+
+  keys_before = set(vine.state_dict())
+  vine.pdf(data, batched=True)
+  vine.rosenblatt(data, batched=True)
+  assert set(vine.state_dict()) == keys_before
+
+  fresh = TorchVinecop.from_vinecop(cpp)
+  fresh.load_state_dict(vine.state_dict(), strict=True)
+  torch.testing.assert_close(fresh.pdf(data), vine.pdf(data))


### PR DESCRIPTION
## Why

`TorchVinecop.state_dict()` grew from 42 keys to 82 the first time anything was evaluated with `batched=True`, and a checkpoint taken after that call could not be loaded into a fresh model:

```python
vine = TorchVinecop.from_vinecop(cpp)
len(vine.state_dict())          # 42
vine.pdf(u, batched=True)
len(vine.state_dict())          # 82
TorchVinecop.from_vinecop(cpp).load_state_dict(vine.state_dict())
# RuntimeError: Unexpected key(s) in state_dict: "_batched.grid_points", ...
```

What went into a checkpoint depended on whether the model had been evaluated yet, which is not a property a checkpoint should have.

## What changed

The batched state is a memo derived from the pair copulas — stacked grids and wire-up tensors, all recomputable — but assigning it to an attribute of an `nn.Module` registers it as a child module, so its buffers joined the model's own. It is now assigned through `object.__setattr__`, so it stays an ordinary attribute.

Nothing else changes: `TorchVinecop._apply` already drops the cache on every device move, so the registration was never what made `.to()` work.

## Testing

`tests/test_torch_*.py`: 100 passed (CPU). New test asserts the key set is unchanged across a batched `pdf` and `rosenblatt`, and that a fresh model loads the checkpoint with `strict=True`. Also verified by hand: batched and non-batched agree to 1e-12, and `.to("cpu")` still re-bakes the cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
