### PR TITLE
ci: restore the Test PyPI rehearsal and bump the workflow actions

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Set up uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           cache-dependency-glob: pyproject.toml
@@ -126,7 +126,7 @@ jobs:
         with:
           python-version: 3.11
       - name: Set up uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
       - name: Install C++ dependencies
@@ -155,7 +155,7 @@ jobs:
         run: |
           rm -rf build wheelhouse
       - name: Build and test wheels
-        uses: pypa/cibuildwheel@v3.2.0
+        uses: pypa/cibuildwheel@v4.2.0
         env:
           CIBW_REBUILD: 1
           CIBW_BUILD: cp${{ matrix.python }}-${{ matrix.cfg.cibw_id }}
@@ -185,7 +185,7 @@ jobs:
             exit 1
           }
       - name: Upload binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cibw-wheels-${{ matrix.cfg.os }}-${{ matrix.python }}-${{ matrix.cfg.cibw_id }}
           path: ./wheelhouse/*.whl
@@ -204,11 +204,11 @@ jobs:
 
     steps:
       - name: Set up uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
       - name: Download cibw artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           pattern: cibw-*
           path: dist
@@ -246,7 +246,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Set up uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
       - name: Install Graphviz + Pandoc
@@ -263,7 +263,7 @@ jobs:
           apt_retry update
           apt_retry install -y graphviz pandoc
       - name: Download built wheel (cp311 manylinux ubuntu)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: cibw-wheels-ubuntu-latest-311-manylinux_x86_64
           path: dist/
@@ -279,7 +279,7 @@ jobs:
           UV_NO_SYNC: "1"
         run: make docs
       - name: Upload built HTML for PR review
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: docs-html
           path: docs/_build/html/
@@ -316,7 +316,7 @@ jobs:
         with:
           python-version: ${{ steps.pyver.outputs.version }}
       - name: Set up uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           cache-dependency-glob: pyproject.toml
@@ -367,13 +367,13 @@ jobs:
           uv sync --no-install-project --group test --group notebooks --extra examples --extra sklearn --extra torch
       - name: Download built wheel (<=3.11)
         if: ${{ matrix.python <= 311 }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: cibw-wheels-${{ matrix.cfg.os }}-${{ matrix.python }}-${{ matrix.cfg.cibw_id }}
           path: dist/
       - name: Download built wheel (>=3.12, reuses 3.12 ABI3 artifact)
         if: ${{ matrix.python >= 312 }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: cibw-wheels-${{ matrix.cfg.os }}-312-${{ matrix.cfg.cibw_id }}
           path: dist/
@@ -384,7 +384,7 @@ jobs:
       - name: Run tests
         # UV_NO_SYNC: test the pre-installed wheel, not an editable rebuild.
         # Serial — see pyproject.toml's pytest config.
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         env:
           UV_NO_SYNC: "1"
         with:
@@ -395,7 +395,7 @@ jobs:
           command: |
             uv run pytest tests/ -r a --no-cov --reruns 2 --reruns-delay 10
       - name: Run notebooks as unit tests
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         env:
           UV_NO_SYNC: "1"
         with:
@@ -436,7 +436,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Set up uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           cache-dependency-glob: pyproject.toml
@@ -452,7 +452,7 @@ jobs:
           apt_retry update
           apt_retry install -y graphviz
       - name: Download built wheel (cp311 ABI3, ubuntu)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: cibw-wheels-ubuntu-latest-311-manylinux_x86_64
           path: dist/
@@ -516,7 +516,7 @@ jobs:
         with:
           python-version: 3.11
       - name: Set up uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           cache-dependency-glob: pyproject.toml
@@ -548,7 +548,7 @@ jobs:
           VIRTUAL_ENV="$PWD/.venv-sdist" uv run --active \
             pytest tests/ -r a --no-cov --reruns 2 --reruns-delay 10
       - name: Upload binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cibw-sdist
           path: dist/*.tar.gz
@@ -573,11 +573,11 @@ jobs:
         if: ${{ startsWith(github.event.ref, 'refs/tags') }}
         run: python3 scripts/check_version.py --released --tag "$GITHUB_REF_NAME"
       - name: Set up uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
       - name: Download cibw artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           pattern: cibw-*
           path: dist

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -9,6 +9,11 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
+    inputs:
+      test_pypi:
+        description: Publish the built artifacts to Test PyPI (release rehearsal)
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -594,6 +599,21 @@ jobs:
             echo "::error ::Metadata check failed — would fail on PyPI upload."
             exit 1
           }
+      # Rehearsal for the real upload: the same artifacts, action and
+      # credentialing path, against a registry where a mistake is survivable.
+      # Manual because it is one-shot -- Test PyPI refuses a re-upload of a
+      # version it already has, just as PyPI does -- so it is spent
+      # deliberately, on the commit about to be tagged.
+      - name: Publish distribution to Test PyPI
+        if: |
+          job.status == 'success'
+            && github.event_name == 'workflow_dispatch'
+            && inputs.test_pypi
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.test_pypi_password }}
+          repository-url: https://test.pypi.org/legacy/
       - name: Publish distribution to PyPI
         if: |
           job.status == 'success'

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -23,7 +23,18 @@ indistinguishable from an unreleased one.
 3. **Check the metadata agrees**: `uv run python scripts/check_version.py`.
    CI runs the same check on every pull request.
 
-4. **Merge**, then tag the merge commit:
+4. **Rehearse the upload** (optional, but the only way to exercise the publish
+   path before the irreversible one). Run the *Build Status* workflow manually
+   from the Actions tab against the commit you are about to tag, with
+   **Publish the built artifacts to Test PyPI** ticked. It builds the same
+   wheels and sdist the tag would and uploads them to
+   [Test PyPI](https://test.pypi.org/project/pyvinecopulib/).
+
+   Test PyPI refuses a re-upload of a version it already has, exactly as PyPI
+   does, so this is one shot per version — spend it on the commit you mean to
+   tag, not on a work in progress. Needs the `test_pypi_password` secret.
+
+5. **Merge**, then tag the merge commit:
 
    ```bash
    git checkout main && git pull
@@ -35,15 +46,15 @@ indistinguishable from an unreleased one.
    > number.** A mistagged release cannot be undone — only superseded by a new
    > version. Confirm the tag points at the commit you mean before pushing.
 
-5. **Confirm the release landed**: wheels and the sdist on PyPI, the GitHub
+6. **Confirm the release landed**: wheels and the sdist on PyPI, the GitHub
    release created from the changelog section, Read the Docs built the tag with
    `stable` repointed at it, and the Zenodo deposition.
 
-6. **Open the next cycle immediately.** Add a fresh
+7. **Open the next cycle immediately.** Add a fresh
    `## X.Y+1.0 (unreleased)` heading to `CHANGELOG.md` in a follow-up pull
    request, so the next change has somewhere to go.
 
-7. **If the release surfaced a problem in the C++ library**, file it upstream
+8. **If the release surfaced a problem in the C++ library**, file it upstream
    rather than working around it here — the docstrings, signatures and CMake
    seams all belong to `vinecopulib`.
 
@@ -55,6 +66,7 @@ indistinguishable from an unreleased one.
 | wheels, sdist, tests, docs | every pull request |
 | `scripts/check_version.py --released --tag` | on a `v*` tag push, before publishing |
 | publish to PyPI + GitHub release | on a `v*` tag push |
+| publish to Test PyPI | manually, from the Actions tab (see step 4) |
 
 ## Version numbers
 


### PR DESCRIPTION
Two CI changes for the 1.0.0 cycle.

## 1. Restore the Test PyPI rehearsal

The dry-run upload was dropped earlier in the stack. It is back, on a trigger that can actually fire: `workflow_dispatch` with a `test_pypi` input, rather than a branch condition that never matched.

It is manual by design — Test PyPI refuses a re-upload of a version it already has, exactly as PyPI does, so the rehearsal is spent once per version.

## 2. Fold in the Dependabot bumps (#269–#273)

Dependabot opened five pull requests once `main` became the active branch. Consolidated here so the release cycle sees one CI-focused change rather than five full-matrix runs.

| Action | From | To |
|---|---|---|
| `pypa/cibuildwheel` | 3.2.0 | 4.2.0 |
| `actions/download-artifact` | 4 *and* 5 | 8 |
| `actions/upload-artifact` | 4 | 7 |
| `astral-sh/setup-uv` | 6 | 7 |
| `nick-fields/retry` | 3 | 4 |

`download-artifact` was pinned at two different majors across its six call sites; it is uniform now.

### Two of these are more than a version string

**cibuildwheel 4.0** runs `abi3audit` after the repair step by default. This project ships a real limited-API wheel (`nanobind_add_module(... STABLE_ABI ...)` with `wheel.py-api = "cp312"`), so every build now verifies that claim instead of taking it on trust — worth having, since a wheel that falsely claims abi3 fails at runtime on a later Python rather than at build time.

**download-artifact 8** no longer unzips unconditionally; it checks `Content-Type` first. That touches how wheels are gathered before an upload, and it lands in `upload_to_pypi` — the one job no pull request ever runs.

That risk is bounded three ways:

1. `check_wheels` downloads the same artifacts with the same `pattern` / `merge-multiple` invocation and asserts the same wheel count, on every pull request — a shape change fails there first.
2. `upload_to_pypi` counts wheels before uploading, so the failure mode is a refusal to publish, not a bad publish. No version number is consumed.
3. The rehearsal restored above exercises the rest of that path before a tag makes it irreversible.

Recommended order: merge this, then run the rehearsal from the Actions tab, then tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)