### PR TITLE
fix(build): declare base classes in the generated type stubs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
 - Reject non-finite `X` / `y` in the `pyvinecopulib.sklearn` estimators instead of passing them to `Kde1d`, which reads NaN as a segmentation fault (#263).
 - Port the `integrate_2d` marginal-renormalization fix to the torch backend (`InterpolationGrid2D.integrate_2d` and `integrate_2d_batched`) so `TorchBicop.cdf` enforces ``C(1, u_2) = u_2`` exactly, matching the post-vinecopulib#667 C++ CDF to machine precision on the on-the-fly path ([vinecopulib#667](https://github.com/vinecopulib/vinecopulib/pull/667)).
 - Declare `BicopFamily` enum members as class attributes in the generated type stubs so the documented `pv.BicopFamily.clayton` access pattern passes static type checking (`ty` / pyright / mypy), not only the module-level constants (#223).
+- Declare base classes in the generated type stubs, so `DVineStructure` and `CVineStructure` are recognized as `RVineStructure` subclasses. Passing either where an `RVineStructure` is expected -- the documented way to build a C- or D-vine -- no longer fails static type checking, although it always worked at runtime (#268).
 
 ### Dependency changes
 

--- a/scripts/generate_stubs.py
+++ b/scripts/generate_stubs.py
@@ -125,7 +125,14 @@ def infer_method_decorator(name: str, docstring: str) -> Optional[str]:
 def render_class_stub(
   cls, name: str, known_types: Optional[set[str]] = None, indent: int = 2
 ) -> list[str]:
-  lines = [f"class {name}:"]
+  # A base is declared only when it is a bound class from the same module, so
+  # the stub that names it also defines it; ``object`` and foreign bases such as
+  # ``enum.Enum`` have no definition here. Emission order is alphabetical, which
+  # can put a base after its subclass -- legal, as a stub is never executed.
+  bases = ", ".join(
+    b.__name__ for b in cls.__bases__ if b.__module__ == cls.__module__
+  )
+  lines = [f"class {name}({bases}):" if bases else f"class {name}:"]
   doc = inspect.getdoc(cls)
   inner_indent = " " * indent
   if doc:

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -8,6 +8,7 @@ gitignored stub artifacts on disk.
 import importlib.util
 from pathlib import Path
 
+import pyvinecopulib as pv
 from pyvinecopulib.families import BicopFamily
 
 _SCRIPTS = (
@@ -132,3 +133,28 @@ def test_no_binding_is_an_overload_set():
     "bound as overload sets; bind a named factory instead: "
     + ", ".join(sorted(set(overloaded)))
   )
+
+
+def test_subclass_declares_its_base():
+  """``DVineStructure`` / ``CVineStructure`` derive from ``RVineStructure``.
+
+  The binding declares the inheritance and the runtime MRO carries it, so the
+  stub has to as well: passing a D-vine wherever an ``RVineStructure`` is
+  expected is the documented way to use one, and a stub that omits the base
+  makes that a type error.
+  """
+  gen = _load_generator()
+  for cls in (pv.DVineStructure, pv.CVineStructure):
+    body = "\n".join(gen.render_class_stub(cls, cls.__name__))
+    assert body.startswith(f"class {cls.__name__}(RVineStructure):")
+
+
+def test_base_without_a_definition_here_is_not_declared():
+  """Only bases the stub itself defines are named.
+
+  ``BicopFamily`` derives from ``enum.Enum``, which the stub never declares, so
+  naming it would leave a dangling reference.
+  """
+  gen = _load_generator()
+  body = "\n".join(gen.render_class_stub(BicopFamily, "BicopFamily"))
+  assert body.startswith("class BicopFamily:")


### PR DESCRIPTION
Found while type-checking a test in #265.

`render_class_stub` emitted `class {name}:` unconditionally, so a bound class lost its base class in the generated `.pyi`. The binding declares `nb::class_<DVineStructure, RVineStructure>` and the runtime MRO is correct, but the stub said `class DVineStructure:` — and the package ships `py.typed`, so every user's type checker saw the two classes as unrelated:

```python
pv.Vinecop.from_structure(structure=pv.DVineStructure(order=[1, 2, 3]))
# error: Expected `RVineStructure | None`, found `DVineStructure`
```

That is the documented way to build a D-vine. It worked at runtime and failed static checking, while the class docstring promises the opposite in as many words: *"``DVineStructure`` objects inherit the methods and attributes of ``RVineStructure`` objects."*

Worth fixing before the tag rather than after: 1.0.0 freezes this into the stable typed surface.

## What changed

A base is declared when it is a bound class from the same module, so the stub that names it also defines it. Skipped otherwise:

- `object` — nothing to declare.
- foreign bases — `BicopFamily` derives from `enum.Enum`, which the stub never declares; naming it would leave a dangling reference.

Classes are emitted alphabetically, so `RVineStructure` lands after both subclasses. That is fine in a stub, which is read rather than executed.

Inherited members were already re-emitted into each subclass body, so this adds the missing assignability, not the members.

## Verification

Both of these failed before and pass now:

```python
d = pv.DVineStructure(order=[1, 2, 3])
c = pv.CVineStructure(order=[1, 2, 3])
print(d.dim, c.order, d.matrix)
pv.Vinecop.from_structure(structure=d)
```

Two tests in `tests/test_stubs.py` — one pinning that the subclasses declare `RVineStructure`, one pinning that `BicopFamily` does *not* declare `enum.Enum`. The first fails without the fix.

Local: `make lint`, `ty check`, 466 tests, `make docs` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)