### PR TITLE
refactor(sklearn)!: delegate to Vinedist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 - `BicopLike` / `BicopBase` take the conditioning matrix `x` as a keyword-only argument, matching `VinecopLike`. It shared a positional slot with the compiled `Bicop`'s per-row `parameters`, so hosting a `pv.Bicop` in a non-simplified `VinecopBase` silently evaluated the conditioning values as parameters; it now raises `TypeError` (#265).
 - `Kde1d`'s `quantile` method is renamed to `Kde1d.icdf`, matching what both SciPy's modern distribution classes and `torch.distributions` call the inverse CDF, and freeing the name `quantile` of its usual Python meaning of *sample* quantiles. No alias: replace `kde.quantile(p)` with `kde.icdf(p)`.
 - `FitControlsBicop` and `FitControlsVinecop` default `selection_criterion` to `"aic"` instead of `"bic"`, matching the C++ and R defaults; the same knob now selects the same model from all three languages. Pass `selection_criterion="bic"` explicitly to keep the previous selection (#251).
+- `VineDensity` and `VineRegressor` take a `margins=` keyword and delegate the whole marginal half to `Vinedist`, so the Sklar assembly has one implementation instead of two. `margins=None` still fits a `Kde1d` per column and reproduces the previous numbers; the internal `_x_kde1d` / `_y_kde1d` attributes are gone (the fitted margins are `distribution_.margins`), and `margins` sits between `backend` and `batch_size`, so a positional call past `backend` shifts.
+- `VineRegressor` requires a continuous response margin, and `use_grid=True` additionally requires it to be a `Kde1dMargin`, since that is where the quadrature nodes come from; pass `use_grid=False` to use any other response margin.
 
 ### New features in `pyvinecopulib`
 
@@ -66,6 +68,10 @@
 - Add `RVineStructure.get_min_array()`, `get_needed_hfunc1()` and `get_needed_hfunc2()`, returning the whole `[tree][edge]` triangular array that the existing per-entry accessors index into (#251).
 - `Vinecop.pair_copulas` is now settable, so pair copulas can be replaced as a group on a fitted vine; the assignment validates the nested shape against the structure (#251).
 
+- The sklearn estimators publish the fitted model as `distribution_`, a `Vinedist` that evaluates through the fitted backend, and the family-selection table of any selecting margin as `selection_report_`.
+- Add `Vinedist.copula_data` and `Vinedist.copula_var_types`: from a set of margins, the copula-scale layout for some data and the `var_types` a copula must be fitted with. That is what "fit your own copula, then wrap it" needs, and what the sklearn estimators use.
+- `resolve_margins` takes `default=`, one specification per variable, so a caller that knows something per variable keeps it for the variables a mapping does not address.
+
 ### Build / packaging
 
 - Migrate to `uv` + `scikit-build-core` for the editable / wheel build pipeline, with `[build-system].requires` mirroring the dev `[dependency-groups]` so `--no-build-isolation` works out of the box (#209).
@@ -88,6 +94,9 @@
 - Reject non-finite `X` / `y` in the `pyvinecopulib.sklearn` estimators instead of passing them to `Kde1d`, which reads NaN as a segmentation fault (#263).
 - Port the `integrate_2d` marginal-renormalization fix to the torch backend (`InterpolationGrid2D.integrate_2d` and `integrate_2d_batched`) so `TorchBicop.cdf` enforces ``C(1, u_2) = u_2`` exactly, matching the post-vinecopulib#667 C++ CDF to machine precision on the on-the-fly path ([vinecopulib#667](https://github.com/vinecopulib/vinecopulib/pull/667)).
 - Declare `BicopFamily` enum members as class attributes in the generated type stubs so the documented `pv.BicopFamily.clayton` access pattern passes static type checking (`ty` / pyright / mypy), not only the module-level constants (#223).
+- Fit the `{0, 1}` dummies of an expanded unordered categorical on `[0, 1]` in the sklearn estimators. Their bounds are known exactly, but were never passed, so the kernel-density grid was padded past the data and put mass on values that cannot occur.
+- `Vinedist.cdf` hands the copula the full `(n, d + k)` layout. A distribution function needs only the marginal `F` values and the copula reads only those, but it validates the whole layout, so a margin with atoms made `cdf` raise.
+- Reject complex `X` / `y` in the sklearn estimators rather than casting each column to float and dropping the imaginary part in silence.
 
 ### Dependency changes
 

--- a/src/pyvinecopulib/core/vinedist.py
+++ b/src/pyvinecopulib/core/vinedist.py
@@ -128,10 +128,7 @@ class Vinedist(Generic[ArrayT]):
 
     self._copula = copula
     self._margins = tuple(resolved)
-    self._var_types = [
-      "d" if getattr(m, "var_type", "c") in ("d", "zi") else "c"
-      for m in self._margins
-    ]
+    self._var_types = self.copula_var_types(self._margins)
 
     declared = getattr(copula, "var_types", None)
     if declared is not None and list(declared) != self._var_types:
@@ -250,16 +247,45 @@ class Vinedist(Generic[ArrayT]):
     cols = [m.icdf(ua[:, j]) for j, m in enumerate(self._margins)]
     return cast(ArrayT, xp.stack(cols, axis=-1))
 
-  def _u_layout(self, x: ArrayT) -> Any:
-    """Assemble the copula-scale data in the layout the copula expects.
+  @staticmethod
+  def copula_var_types(margins: Sequence[Any]) -> list[str]:
+    """Variable types a copula must be fitted with to host these margins.
+
+    Parameters
+    ----------
+    margins : sequence of MarginLike
+        One margin per variable, in variable order. Foreign distribution
+        objects are coerced with :func:`pyvinecopulib.margins.as_margin`, since
+        a bare one carries no variable type of its own.
+
+    Returns
+    -------
+    list of str
+        ``"c"`` or ``"d"`` per variable; a zero-inflated margin is ``"d"``,
+        since what the copula needs from it is the left limit.
+    """
+    from ..margins import as_margin
+
+    return [
+      "d" if getattr(as_margin(m), "var_type", "c") in ("d", "zi") else "c"
+      for m in margins
+    ]
+
+  @staticmethod
+  def copula_data(margins: Sequence[Any], x: Any) -> Any:
+    """Assemble the copula-scale data in the layout a copula expects.
 
     Continuous variables contribute one column each. A variable with atoms
     contributes a second, its left limit ``F(x^-)``, appended after the first
     block in variable order — the compact ``(n, d + k)`` layout. Users never
-    build this by hand, which is the point.
+    build this by hand, which is the point, and neither does code that fits its
+    own copula before handing it to ``Vinedist``.
 
     Parameters
     ----------
+    margins : sequence of MarginLike
+        One margin per variable, in variable order. Foreign distribution
+        objects are coerced with :func:`pyvinecopulib.margins.as_margin`.
     x : array, shape (n, d), dtype float
         Observations on the original scale.
 
@@ -271,13 +297,23 @@ class Vinedist(Generic[ArrayT]):
     Raises
     ------
     ValueError
-        If a margin reports a left limit above its own distribution function.
+        If ``x`` does not carry one column per margin, or if a margin reports a
+        left limit above its own distribution function.
     """
-    xp, xa, _ = self._columns(x)
-    upper = [m.cdf(xa[:, j]) for j, m in enumerate(self._margins)]
+    from ..margins import as_margin
+
+    resolved = [as_margin(m) for m in margins]
+    var_types = Vinedist.copula_var_types(resolved)
+    xa: Any = x
+    xp = array_namespace(xa)
+    if xa.ndim != 2 or xa.shape[1] != len(resolved):
+      raise ValueError(
+        f"x must have shape (n, {len(resolved)}); got {tuple(xa.shape)}"
+      )
+    upper = [m.cdf(xa[:, j]) for j, m in enumerate(resolved)]
     lower = []
-    for j, m in enumerate(self._margins):
-      if self._var_types[j] != "d":
+    for j, m in enumerate(resolved):
+      if var_types[j] != "d":
         continue
       left = getattr(m, "cdf_left", None)
       sub = upper[j] if left is None else left(xa[:, j])
@@ -289,6 +325,21 @@ class Vinedist(Generic[ArrayT]):
       lower.append(sub)
     block = xp.stack([*upper, *lower], axis=-1)
     return xp.clip(block, _TRIM_LO, _TRIM_HI)
+
+  def _u_layout(self, x: ArrayT) -> Any:
+    """This distribution's copula-scale data for ``x``.
+
+    Parameters
+    ----------
+    x : array, shape (n, d), dtype float
+        Observations on the original scale.
+
+    Returns
+    -------
+    array, shape (n, d + k), dtype float
+        The copula-scale data.
+    """
+    return self.copula_data(self._margins, x)
 
   # --- evaluation ---------------------------------------------------------- #
 
@@ -359,7 +410,10 @@ class Vinedist(Generic[ArrayT]):
     array, shape (n,), dtype float
         Joint distribution values in ``[0, 1]``.
     """
-    return self._copula.cdf(self.marginal_cdf(x), **kwargs)
+    # A distribution function needs only the marginal `F` values, and the
+    # copula reads only those; but a copula with atoms validates the whole
+    # layout, so give it the layout rather than the first block alone.
+    return self._copula.cdf(cast(ArrayT, self._u_layout(x)), **kwargs)
 
   def loglik(self, x: ArrayT) -> ArrayT:
     """Log-likelihood of the observations.
@@ -493,16 +547,11 @@ class Vinedist(Generic[ArrayT]):
       fit_margin(specs[j], data[:, j], weights=weights) for j in range(d)
     ]
 
-    # A copula needs its var_types up front, so the layout is built from the
-    # fitted margins before the copula exists; `_bind_dist` then re-derives and
+    # A copula needs its var_types up front, so both come from the fitted
+    # margins before the copula exists; `_bind_dist` then re-derives and
     # cross-checks them.
-    stub = object.__new__(cls)
-    stub._copula = cast(Any, None)
-    stub._margins = tuple(fitted)
-    stub._var_types = [
-      "d" if getattr(m, "var_type", "c") in ("d", "zi") else "c" for m in fitted
-    ]
-    u = stub._u_layout(cast(Any, data))
+    var_types = cls.copula_var_types(fitted)
+    u = cls.copula_data(fitted, data)
 
     if controls is None:
       controls = FitControlsVinecop()
@@ -511,7 +560,7 @@ class Vinedist(Generic[ArrayT]):
     copula = Vinecop.from_data(
       data=u,
       structure=structure,
-      var_types=stub._var_types,
+      var_types=var_types,
       controls=controls,
     )
     return cls(copula, list(fitted))

--- a/src/pyvinecopulib/margins/_resolve.py
+++ b/src/pyvinecopulib/margins/_resolve.py
@@ -75,15 +75,15 @@ def resolve_margins(
   d: int,
   *,
   names: Optional[Sequence[str]] = None,
+  default: Optional[Sequence[Any]] = None,
 ) -> list[Any]:
   """Expand ``spec`` into one specification per variable.
 
   Accepted forms, in the order they are recognized: ``None`` (the default
-  kernel-density margin), a string alias (``"kde"``, ``"empirical"``,
-  ``"parametric"``), a mapping keyed by variable name or position over a
-  default, a sequence of length ``d`` mixing any of the above, a single margin
-  broadcast to every variable, or a callable receiving a column and returning a
-  margin.
+  margin), a string alias (``"kde"``, ``"empirical"``, ``"parametric"``), a
+  mapping keyed by variable name or position over the default, a sequence of
+  length ``d`` mixing any of the above, a single margin broadcast to every
+  variable, or a callable receiving a column and returning a margin.
 
   A broadcast margin is **copied** per variable rather than shared: margins are
   mutable, and one estimator fitted repeatedly would carry state between
@@ -97,6 +97,13 @@ def resolve_margins(
       Number of variables.
   names : sequence of str, or None, optional
       Variable names, needed only to resolve a mapping keyed by name.
+  default : sequence, or None, optional
+      What an unaddressed variable gets, one entry per variable. ``None`` means
+      a kernel-density margin throughout. Worth setting whenever the caller
+      knows something per variable that the library cannot: the sklearn
+      estimators pass the variable types and bounds they inferred from the
+      data, so a mapping that addresses one column does not silently retype the
+      others.
 
   Returns
   -------
@@ -109,11 +116,20 @@ def resolve_margins(
       If a sequence has the wrong length, or a mapping names an unknown
       variable.
   """
+  if default is None:
+    base = [_prototype("kde") for _ in range(d)]
+  elif len(default) != d:
+    raise ValueError(
+      f"default has length {len(default)}, but there are {d} variables"
+    )
+  else:
+    base = [_resolve_one(entry) for entry in default]
+
   if spec is None:
-    spec = "kde"
+    return base
 
   if isinstance(spec, dict):
-    resolved: list[Any] = [_prototype("kde") for _ in range(d)]
+    resolved: list[Any] = list(base)
     lookup = {name: j for j, name in enumerate(names or [])}
     for key, value in spec.items():
       if isinstance(key, str):

--- a/src/pyvinecopulib/sklearn/__init__.py
+++ b/src/pyvinecopulib/sklearn/__init__.py
@@ -4,10 +4,9 @@ This subpackage wraps the core pyvinecopulib machinery behind the
 standard sklearn ``BaseEstimator`` / ``fit`` / ``predict`` interface.
 Two estimators ship:
 
-- :class:`VineDensity` — non-parametric joint-density estimator. Fits
-  univariate marginals with :class:`pyvinecopulib.utils.Kde1d`, then a
-  vine copula on the resulting pseudo-observations. Exposes
-  ``score_samples`` / ``pdf`` / ``cdf`` / ``sample``.
+- :class:`VineDensity` — joint-density estimator. Fits univariate
+  margins, then a vine copula on the resulting pseudo-observations.
+  Exposes ``score_samples`` / ``pdf`` / ``cdf`` / ``sample``.
 - :class:`VineRegressor` — non-parametric conditional mean / quantile
   regressor built from a vine copula over ``(Y, X)``. Predictions are
   weighted statistics of the training responses.
@@ -22,6 +21,15 @@ Requires scikit-learn and pandas. Install with
 
 Notes
 -----
+**Margins.** The marginal half of the model is configured with
+``margins=``, in any form :func:`pyvinecopulib.margins.resolve_margins`
+accepts: an alias (``"kde"``, the default, ``"empirical"``,
+``"parametric"``), one margin broadcast to every column, a per-column
+sequence, a mapping keyed by feature name, or a callable. Fitting
+assembles both halves into a :class:`pyvinecopulib.core.Vinedist`,
+published as ``distribution_``; ``selection_report_`` carries the
+per-candidate table of any margin that chose its own family.
+
 **Backends.** By default the estimators run on ``Vinecop`` (the
 default backend), so the sklearn module
 **does not require PyTorch**. Pass a configured

--- a/src/pyvinecopulib/sklearn/_base.py
+++ b/src/pyvinecopulib/sklearn/_base.py
@@ -1,5 +1,7 @@
+import copy
 import warnings
 from numbers import Integral
+from typing import Any, Optional
 
 import numpy as np
 import pandas as pd
@@ -12,29 +14,41 @@ from sklearn.utils.validation import (
   check_random_state,
 )
 
-import pyvinecopulib as pv
-
-from .backends import resolve_backend
+from ..core import Vinedist
+from ..margins import Kde1dMargin, resolve_margins
+from ..margins._resolve import fit_margin
+from .backends import _BackendVinecop, resolve_backend
 
 # Shared docstring fragments interpolated into VineDensity / VineRegressor
 # class docstrings via f-strings. Defined once here, used by both subclasses
 # so changes propagate without copy-paste.
 
 _DOC_PIPELINE = r"""The estimator follows the standard pyvinecopulib
-two-step pipeline: a univariate kernel density estimator
-(``Kde1d``) is fit to each column, the marginal CDFs transform the data
-to pseudo-observations
+two-step pipeline: a univariate margin is fit to each column, the
+marginal CDFs transform the data to pseudo-observations
 :math:`U_j = \hat F_j(X_j) \in [0, 1]`, and a vine copula is fit on
-the pseudo-observations. For discrete columns the left limit
+the pseudo-observations. For columns with atoms the left limit
 :math:`\hat F_j(X_j^-)` is also stacked so the vine sees a continuous
 proxy. Unordered categoricals are first expanded to ordered
 ``{0, 1}`` dummies via `expand_factors`.
 
-Fit-time configuration is bundled in a backend object passed via
-``backend=``. The default ``VinecopBackend`` wraps ``Vinecop`` and has
-no extra dependencies; ``TorchVinecopBackend`` routes the same
-pipeline through the PyTorch evaluator (GPU / autograd). See the
-:doc:`concepts page </concepts>` for the underlying vine-copula
+The two halves are configured separately and symmetrically. Margins
+come from ``margins=``, which defaults to a boundary-corrected kernel
+density (``Kde1dMargin``) per column and accepts anything
+:func:`pyvinecopulib.margins.resolve_margins` understands --- an alias
+such as ``"empirical"`` or ``"parametric"``, one margin broadcast to
+every column, a per-column sequence, or a mapping keyed by feature
+name. The copula comes from ``backend=``: the default
+``VinecopBackend`` wraps ``Vinecop`` and has no extra dependencies,
+while ``TorchVinecopBackend`` routes the same pipeline through the
+PyTorch evaluator (GPU / autograd).
+
+Fitting assembles a ``Vinedist`` --- the copula and its margins as one
+object --- and every post-fit method evaluates through it. It is
+published as ``distribution_``, so the fitted joint distribution is
+usable outside the estimator; ``selection_report_`` carries the
+per-candidate table of any margin that selected its own family. See
+the :doc:`concepts page </concepts>` for the underlying vine-copula
 construction.
 """
 
@@ -54,7 +68,8 @@ vine structure (Bedford & Cooke, 2002; Aas et al., 2009). Passing
 """
 
 _DOC_DISCRETE = r"""Discrete (or expanded unordered-categorical)
-columns are handled via ``Kde1d``'s ``type="discrete"`` mode:
+columns are handled by the margin's own variable type --- for the
+default ``Kde1dMargin`` that is ``type="discrete"``:
 pseudo-observations stack :math:`\hat F_j(X_j)` and
 :math:`\hat F_j(X_j^-)` so the vine evaluation sees the appropriate
 continuous proxy. Handled transparently by `fit` and `pdf`.
@@ -128,10 +143,11 @@ class VineBase(BaseEstimator):
   Base class for vine-copula based estimators.
 
   Provides common functionality for:
-  - Marginal distribution fitting (Kde1d)
+  - Marginal distribution fitting (via ``margins=``)
   - Data preprocessing and validation
   - Pseudo-observation transformation
   - Vine copula fitting (via a backend strategy object)
+  - Assembling both halves into a fitted ``Vinedist``
   - Batched operations
 
   Per the scikit-learn developer guide, ``__init__`` only stores
@@ -140,8 +156,15 @@ class VineBase(BaseEstimator):
   convention.
   """
 
+  # `schema_` is heterogeneous by design -- per-column variable types, and the
+  # bounds of the columns whose support the input pinned down. Declared here so
+  # the type checker knows that; `_validate_input(reset=True)` sets it, and
+  # `getattr(self, "schema_", None)` is still how a caller-set one is read.
+  schema_: dict[str, Any]
+
   _parameter_constraints: dict = {
     "backend": [object, None],
+    "margins": [object, None],
     "batch_size": [Interval(Integral, 1, None, closed="left")],
     "random_state": ["random_state"],
   }
@@ -149,6 +172,7 @@ class VineBase(BaseEstimator):
   def __init__(
     self,
     backend=None,
+    margins=None,
     batch_size: int = 100,
     random_state=None,
   ) -> None:
@@ -162,6 +186,18 @@ class VineBase(BaseEstimator):
         ``FitControlsTorchVinecop`` for the torch backend) and an
         optional structure. `None` resolves to a default
         ``VinecopBackend`` at fit time.
+    margins : object, default=None
+        What to fit to each column, in any form
+        :func:`pyvinecopulib.margins.resolve_margins` accepts: an alias
+        (``"kde"``, ``"empirical"``, ``"parametric"``), one margin
+        broadcast to every column, a sequence of length
+        ``n_features_in_``, a mapping keyed by feature name or
+        position, or a callable taking a column and returning a
+        margin. `None` fits a ``Kde1dMargin`` per column, carrying the
+        variable type inferred from the input and, for the ``{0, 1}``
+        dummies of an expanded unordered categorical, the bounds of its
+        support. Stored as-is and never mutated: every specification is
+        fitted on a copy.
     batch_size : int, default=100
         Number of test points to process per batch when making
         predictions. ``1`` minimizes memory at the cost of speed;
@@ -174,6 +210,7 @@ class VineBase(BaseEstimator):
         inside `fit`.
     """
     self.backend = backend
+    self.margins = margins
     self.batch_size = batch_size
     self.random_state = random_state
 
@@ -233,7 +270,17 @@ class VineBase(BaseEstimator):
           "discrete" if isinstance(dtype, pd.CategoricalDtype) else "continuous"
           for dtype in X_exp.dtypes
         ]
-        self.schema_ = {"kde1d_types": kde1d_types}
+        # `expand_factors` only ever adds columns, so an expanded name absent
+        # from the input is a {0, 1} dummy: its support is known exactly, and
+        # saying so keeps the marginal fit off values that cannot occur. The
+        # bounds of any other discrete column are a modeling assumption the
+        # caller has to make, so they stay unset.
+        original = set(X.columns)
+        bounds: list[Optional[tuple[float, float]]] = [
+          None if name in original else (0.0, 1.0)
+          for name in self._expanded_columns
+        ]
+        self.schema_ = {"kde1d_types": kde1d_types, "bounds": bounds}
         self.n_features_in_ = X_exp.shape[1]
         X_arr = X_exp.to_numpy()
       else:
@@ -255,8 +302,8 @@ class VineBase(BaseEstimator):
         # ``schema_`` set by the caller (or by a subclass) before
         # ``fit`` to declare per-column kde1d types, and otherwise
         # treat every column as continuous.
-        existing = getattr(self, "schema_", None)
-        if existing is not None and "kde1d_types" in existing:
+        existing = getattr(self, "schema_", None) or {}
+        if "kde1d_types" in existing:
           kde1d_types = existing["kde1d_types"]
           if len(kde1d_types) != X.shape[1]:
             raise ValueError(
@@ -265,7 +312,12 @@ class VineBase(BaseEstimator):
             )
         else:
           kde1d_types = ["continuous"] * X.shape[1]
-        self.schema_ = {"kde1d_types": kde1d_types}
+        bounds = existing.get("bounds") or [None] * X.shape[1]
+        if len(bounds) != X.shape[1]:
+          raise ValueError(
+            "schema_['bounds'] length does not match number of features in X."
+          )
+        self.schema_ = {"kde1d_types": kde1d_types, "bounds": bounds}
         self.n_features_in_ = X.shape[1]
       else:
         check_is_fitted(self, attributes=["n_features_in_"])
@@ -273,6 +325,10 @@ class VineBase(BaseEstimator):
           raise ValueError("X has wrong number of features.")
       X_arr = X
 
+    # Margins are fitted on float columns, so a complex input would otherwise
+    # be cast and lose its imaginary part without saying so.
+    if np.iscomplexobj(X_arr) or (y is not None and np.iscomplexobj(y)):
+      raise ValueError("Complex data not supported")
     # The marginal estimator is C++ and reads NaN / inf as a segmentation
     # fault rather than an error, so nothing downstream can report this.
     assert_all_finite(X_arr, input_name="X")
@@ -281,11 +337,96 @@ class VineBase(BaseEstimator):
       return X_arr, y
     return X_arr
 
+  def _column_name(self, j: int) -> str:
+    """Name of expanded column ``j``, for reports and messages.
+
+    Parameters
+    ----------
+    j : int
+        Column index.
+
+    Returns
+    -------
+    str
+        The feature name for DataFrame input, else a positional stand-in.
+    """
+    names = getattr(self, "_expanded_columns", None)
+    if names is not None and j < len(names):
+      return str(names[j])
+    return f"x{j}"
+
+  def _default_margin_specs(self) -> list[Kde1dMargin]:
+    """One unfitted kernel-density margin per column, from the schema.
+
+    This is what ``margins=None`` means, and what a column a ``margins=``
+    mapping does not address falls back to.
+
+    Returns
+    -------
+    list of Kde1dMargin
+        One margin per feature, carrying the variable type and whatever bounds
+        the input told us about.
+    """
+    types = self.schema_["kde1d_types"]
+    bounds = self.schema_.get("bounds") or [None] * len(types)
+    specs = []
+    for type_, bound in zip(types, bounds):
+      lo, hi = (
+        (None, None) if bound is None else (float(bound[0]), float(bound[1]))
+      )
+      specs.append(Kde1dMargin(type=type_, xmin=lo, xmax=hi))
+    return specs
+
+  def _fit_one_margin(self, spec: Any, column: np.ndarray, name: str) -> Any:
+    """Fit one column's margin.
+
+    Parameters
+    ----------
+    spec : object
+        A specification from :func:`pyvinecopulib.margins.resolve_margins`.
+    column : ndarray, shape (n_samples,), dtype float
+        The column to fit.
+    name : str
+        The variable's name, for a selector's report.
+
+    Returns
+    -------
+    MarginLike
+        The fitted margin.
+    """
+    # Fitting a margin mutates it, and `self.margins` is a constructor argument
+    # that has to survive `fit` untouched so `clone` reproduces the estimator;
+    # hence every specification is fitted on a copy of itself.
+    spec = copy.deepcopy(spec)
+    # A selector records which variable each candidate was fitted to; supply
+    # the name when the caller has not.
+    if hasattr(spec, "report_") and getattr(spec, "name", "") is None:
+      spec.name = name
+    return fit_margin(spec, np.asarray(column, dtype=float))
+
+  def _response_margin_spec(self) -> Any:
+    """The specification for the response margin.
+
+    ``margins`` addresses the features, so a per-variable form -- a sequence, or
+    a mapping over the feature names -- says nothing about the response, which
+    keeps the default. Anything that broadcasts (an alias, one margin, a
+    callable) applies to the response too, so ``margins="parametric"`` means
+    what it looks like.
+
+    Returns
+    -------
+    object
+        One specification, not yet fitted.
+    """
+    if isinstance(self.margins, (list, tuple, dict)):
+      return Kde1dMargin()
+    return resolve_margins(self.margins, 1)[0]
+
   def _fit_marginals(
     self, X: np.ndarray, y: np.ndarray | None = None
   ) -> np.ndarray | tuple[np.ndarray, np.ndarray]:
     """
-    Fit marginal distributions (Kde1d) for features and optionally target.
+    Fit one margin per feature column, and the response's when given.
 
     Parameters
     ----------
@@ -301,21 +442,59 @@ class VineBase(BaseEstimator):
     y : ndarray or None
         Target values (unchanged) if provided, None otherwise.
     """
-    self._x_kde1d = []
-    assert (
-      self.schema_ is not None
-    )  # Guaranteed after _validate_input(reset=True)
-    for j in range(self.n_features_in_):
-      kde = pv.utils.Kde1d(type=self.schema_["kde1d_types"][j])
-      kde.fit(X[:, j])
-      self._x_kde1d.append(kde)
+    specs = resolve_margins(
+      self.margins,
+      self.n_features_in_,
+      names=getattr(self, "_expanded_columns", None),
+      default=self._default_margin_specs(),
+    )
+    self._x_margins = tuple(
+      self._fit_one_margin(specs[j], X[:, j], self._column_name(j))
+      for j in range(self.n_features_in_)
+    )
+    fitted = list(self._x_margins)
 
     if y is not None:
-      self._y_kde1d = pv.utils.Kde1d()
-      self._y_kde1d.fit(y)
+      self._y_margin = self._fit_one_margin(
+        self._response_margin_spec(), np.asarray(y, dtype=float), "y"
+      )
+      # The joint model orders the response first and gives it no left-limit
+      # column, which the prediction paths rely on.
+      if Vinedist.copula_var_types([self._y_margin])[0] != "c":
+        raise ValueError(
+          "The response margin must be continuous, but "
+          f"{type(self._y_margin).__name__} declares "
+          f"var_type={getattr(self._y_margin, 'var_type', 'c')!r}."
+        )
+      fitted.append(self._y_margin)
+
+    self.selection_report_ = [
+      dict(row) for margin in fitted for row in getattr(margin, "report_", ())
+    ]
+    if y is not None:
       return X, y
-    else:
-      return X
+    return X
+
+  def _bind_distribution(self, margins: Any) -> None:
+    """Publish the fitted vine and its margins as one ``Vinedist``.
+
+    The copula is wrapped so that it evaluates through the backend, which is
+    what keeps ``distribution_`` numerically identical to the estimator's own
+    methods -- including on the torch backend, where the raw vine returns
+    tensors on its own device.
+
+    Parameters
+    ----------
+    margins : sequence of MarginLike
+        The fitted margins, in the vine's variable order.
+
+    Returns
+    -------
+    None
+    """
+    self.distribution_ = Vinedist(
+      _BackendVinecop(self.backend_, self._vine), list(margins)
+    )
 
   def _resolve_runtime_state(self) -> None:
     """Resolve the random-state and backend at fit time. Sets
@@ -334,14 +513,17 @@ class VineBase(BaseEstimator):
     """
     Compute marginal pseudo-observations for new data, handling discrete vars.
 
+    A thin delegation to ``Vinedist.copula_data``, which owns the layout: one
+    column per variable, then one left-limit column per variable with atoms.
+
     Parameters
     ----------
     Z : array-like
         If is_y=False: shape (n_samples, d).
         If is_y=True : shape (n_samples,).
     is_y : bool, default=False
-        If True, transform response with y_kde1d.
-        If False, transform covariates with x_kde1d list.
+        If True, transform the response with its own margin.
+        If False, transform the covariates with theirs.
 
     Returns
     -------
@@ -349,38 +531,18 @@ class VineBase(BaseEstimator):
         If is_y=False: shape (n_samples, d [+ optional discrete sub-columns]).
         If is_y=True : shape (n_samples, 1).
     """
-    check_is_fitted(self, attributes=["_x_kde1d"])
-    if is_y and not hasattr(self, "_y_kde1d"):
+    check_is_fitted(self, attributes=["_x_margins"])
+    if is_y and not hasattr(self, "_y_margin"):
       raise RuntimeError(
         "Target marginal not fitted (y was not provided during fit)."
       )
 
-    Z = np.asarray(Z)
-
+    Z = np.asarray(Z, dtype=float)
     if is_y:
-      # Response is always treated continuous -> plain PIT.
-      result = self._y_kde1d.cdf(Z.squeeze(), check_fitted=False)
-      return np.asarray(result).reshape(-1, 1)
-
-    n_samples, n_features = Z.shape
-    u_cols = []
-    u_sub_cols = []
-
-    for j in range(n_features):
-      kde = self._x_kde1d[j]
-      zj = Z[:, j]
-      u_cols.append(kde.cdf(zj, check_fitted=False))
-      if kde.type == "discrete":
-        # Sub-CDF F(x^-) for the discrete component.
-        u_sub_cols.append(kde.cdf(zj - 1, check_fitted=False))
-
-    eps = 1e-10
-    u_cols = [np.clip(u, eps, 1 - eps) for u in u_cols]
-    if u_sub_cols:
-      u_sub_cols = [np.clip(u, eps, 1 - eps) for u in u_sub_cols]
-      return np.column_stack([*u_cols, *u_sub_cols])
-    else:
-      return np.column_stack(u_cols)
+      return np.asarray(
+        Vinedist.copula_data([self._y_margin], Z.reshape(-1, 1))
+      )
+    return np.asarray(Vinedist.copula_data(self._x_margins, Z))
 
   def _fit_vine(
     self, U: np.ndarray, var_types: list[str] | None = None
@@ -400,10 +562,7 @@ class VineBase(BaseEstimator):
     self
     """
     if var_types is None:
-      assert (
-        self.schema_ is not None
-      )  # Guaranteed after _validate_input(reset=True)
-      var_types = [x[0] for x in self.schema_["kde1d_types"]]
+      var_types = Vinedist.copula_var_types(self._x_margins)
 
     backend = self.backend_
     self._vine = backend.fit_vine(U, var_types=var_types)
@@ -440,38 +599,23 @@ class VineBase(BaseEstimator):
     density : ndarray of shape (n_samples,)
         Density or log-density values.
     """
-    check_is_fitted(self, attributes=["_vine"])
+    check_is_fitted(self, attributes=["distribution_"])
 
     X = self._validate_input(X, reset=False)
     if y is not None:
-      y = np.asarray(y).reshape(-1, 1)
+      y = np.asarray(y, dtype=float).reshape(-1, 1)
       if X.shape[0] != y.shape[0]:
         raise ValueError("X and y must have the same number of samples.")
-      U = np.column_stack([self._to_u_scale(y, is_y=True), self._to_u_scale(X)])
+      # The joint model orders the response first.
+      Z = np.column_stack([y, X])
     else:
-      U = self._to_u_scale(X)
+      Z = np.asarray(X, dtype=float)
 
-    pdf_vals = np.asarray(self.backend_.pdf(self._vine, U))
-    log_c = np.asarray(np.log(pdf_vals))
-
+    dist = self.distribution_
     if copula_only:
-      return np.asarray(log_c if log else np.exp(log_c))
+      u = Vinedist.copula_data(dist.margins, Z)
+      out = np.log(np.asarray(dist.copula.pdf(u)))
+    else:
+      out = np.asarray(dist.logpdf(Z))
 
-    # Marginal densities; clamp >0 to avoid log(0).
-    eps = 1e-10
-    f_x = np.array(
-      [
-        np.clip(self._x_kde1d[j].pdf(X[:, j]), eps, None)
-        for j in range(self.n_features_in_)
-      ]
-    )
-    log_f_x = np.sum(
-      np.log(f_x),
-      axis=0,
-    )
-    log_density = log_c + log_f_x
-    if y is not None:
-      log_f_y = np.log(self._y_kde1d.pdf(y.squeeze()))
-      log_density += log_f_y
-
-    return np.asarray(log_density if log else np.exp(log_density))
+    return np.asarray(out if log else np.exp(out))

--- a/src/pyvinecopulib/sklearn/backends.py
+++ b/src/pyvinecopulib/sklearn/backends.py
@@ -311,6 +311,109 @@ class TorchVinecopBackend(_VinecopBackendBase):
     return self
 
 
+class _BackendVinecop:
+  """A fitted vine that evaluates through the backend that fitted it.
+
+  The estimators hand this to :class:`~pyvinecopulib.core.Vinedist` in place of
+  the raw vine, so the distribution object evaluates exactly as the estimator
+  does — with the backend's threading / batching arguments, and with results
+  brought back to NumPy from wherever the vine computed them. Anything the
+  backend does not adapt is read off the vine itself, so this still answers
+  ``dim`` / ``var_types`` / ``structure`` and the Rosenblatt pair.
+
+  Parameters
+  ----------
+  backend : object
+      A resolved backend.
+  vine : object
+      The vine that backend fitted.
+  """
+
+  def __init__(self, backend: Any, vine: Any) -> None:
+    self.backend = backend
+    self.vine = vine
+
+  def __getattr__(self, name: str) -> Any:
+    # Underscored names are never forwarded: unpickling looks up `__setstate__`
+    # before `vine` exists, and forwarding it would recurse.
+    vine = self.__dict__.get("vine")
+    if vine is None or name.startswith("_"):
+      raise AttributeError(name)
+    return getattr(vine, name)
+
+  def pdf(self, u: np.ndarray) -> np.ndarray:
+    """Copula density at ``u``.
+
+    Parameters
+    ----------
+    u : ndarray, shape (n, d) or (n, d + k), dtype float
+        Copula-scale data.
+
+    Returns
+    -------
+    ndarray, shape (n,), dtype float
+        Density values.
+    """
+    return self.backend.pdf(self.vine, u)
+
+  def cdf(
+    self,
+    u: np.ndarray,
+    *,
+    N: int = 10000,
+    seeds: Optional[list[int]] = None,
+  ) -> np.ndarray:
+    """Copula distribution function at ``u``.
+
+    Parameters
+    ----------
+    u : ndarray, shape (n, d) or (n, d + k), dtype float
+        Copula-scale data.
+    N : int, optional
+        Number of quasi-random points for the Monte-Carlo integration.
+    seeds : list of int, or None, optional
+        RNG seeds.
+
+    Returns
+    -------
+    ndarray, shape (n,), dtype float
+        Distribution values.
+    """
+    return self.backend.cdf(self.vine, u, N=N, seeds=list(seeds or []))
+
+  def simulate(
+    self, n: int, *, seeds: Optional[list[int]] = None
+  ) -> np.ndarray:
+    """Draw ``n`` samples on the copula scale.
+
+    Parameters
+    ----------
+    n : int
+        Number of samples.
+    seeds : list of int, or None, optional
+        RNG seeds.
+
+    Returns
+    -------
+    ndarray, shape (n, d), dtype float
+        Samples in ``[0, 1]^d``.
+    """
+    return self.backend.simulate(self.vine, n, seeds=list(seeds or []))
+
+  def __repr__(self) -> str:
+    """Name the backend and the vine it wraps.
+
+    Returns
+    -------
+    str
+        The representation.
+    """
+    return (
+      f"_BackendVinecop({type(self.backend).__name__}, "
+      f"{type(self.vine).__name__})"
+    )
+
+
 def resolve_backend(backend: Any) -> Any:
   """Coerce a user-supplied ``backend=`` value to a concrete backend.
 

--- a/src/pyvinecopulib/sklearn/density.py
+++ b/src/pyvinecopulib/sklearn/density.py
@@ -18,6 +18,7 @@ class VineDensity(DensityMixin, VineBase):
   def __init__(
     self,
     backend=None,
+    margins=None,
     batch_size: int = 100,
     random_state=None,
   ) -> None:
@@ -31,6 +32,11 @@ class VineDensity(DensityMixin, VineBase):
         ``VinecopBackend`` at fit time, which calls ``Vinecop.from_data()``
         with the nonparametric ``tll`` pair family. Pass
         ``TorchVinecopBackend`` for the PyTorch backend.
+    margins : object, default=None
+        The marginal half of the model, in any form
+        :func:`pyvinecopulib.margins.resolve_margins` accepts. `None`
+        fits a ``Kde1dMargin`` per column with the variable type
+        inferred from the input.
     batch_size : int, default=100
         Number of test points processed per batch when evaluating
         the density. Higher values trade memory for throughput.
@@ -40,7 +46,10 @@ class VineDensity(DensityMixin, VineBase):
         inside `fit`.
     """
     super().__init__(
-      backend=backend, batch_size=batch_size, random_state=random_state
+      backend=backend,
+      margins=margins,
+      batch_size=batch_size,
+      random_state=random_state,
     )
 
   def fit(self, X, y=None) -> "VineDensity":
@@ -65,9 +74,8 @@ class VineDensity(DensityMixin, VineBase):
     X = self._validate_input(X, reset=True)
     self._resolve_runtime_state()
     self._fit_marginals(X)
-    U = self._to_u_scale(X)
-    var_types = [x[0] for x in self.schema_["kde1d_types"]]
-    self._fit_vine(U, var_types=var_types)
+    self._fit_vine(self._to_u_scale(X))
+    self._bind_distribution(self._x_margins)
     return self
 
   def score_samples(self, X: np.ndarray | pd.DataFrame) -> np.ndarray:
@@ -126,7 +134,7 @@ class VineDensity(DensityMixin, VineBase):
   def sample(self, n_samples: int = 1, random_state=None) -> np.ndarray:
     """Draws samples from the fitted joint density.
 
-    Samples :math:`U \\sim C` via ``Vinecop.simulate()`` and pushes each
+    Samples :math:`U \\sim C` from the fitted copula and pushes each
     component back through the inverse marginal CDF :math:`F_j^{-1}`
     to obtain a sample in the original feature space.
 
@@ -141,9 +149,14 @@ class VineDensity(DensityMixin, VineBase):
     Returns
     -------
     ndarray, shape (n_samples, n_features), dtype float
-        Generated samples in the original feature scale.
+        Generated samples, in the *expanded* feature space -- the one
+        `fit` modeled, with ``n_features_in_`` columns. Dummies of an
+        expanded unordered categorical come back as separate columns
+        rather than as the original level, since a vine draw can put a
+        ``1`` in two of them at once and choosing between those is a
+        modeling decision, not an inverse.
     """
-    check_is_fitted(self, attributes=["_vine"])
+    check_is_fitted(self, attributes=["distribution_"])
     if random_state is None:
       rng = self.random_state_
     else:
@@ -151,13 +164,7 @@ class VineDensity(DensityMixin, VineBase):
 
       rng = check_random_state(random_state)
     seeds = [int(x) for x in rng.randint(0, 2**31 - 1, size=5)]
-    U_sampled = np.asarray(
-      self.backend_.simulate(self._vine, n_samples, seeds=seeds)
-    )
-    X_sampled = np.empty((n_samples, self.n_features_in_))
-    for j in range(self.n_features_in_):
-      X_sampled[:, j] = self._x_kde1d[j].icdf(U_sampled[:, j])
-    return X_sampled
+    return np.asarray(self.distribution_.simulate(n_samples, seeds=seeds))
 
   def pdf(self, X: np.ndarray, copula_only: bool = False) -> np.ndarray:
     """Evaluates the joint density at the given samples.
@@ -217,9 +224,8 @@ class VineDensity(DensityMixin, VineBase):
         `N` if the MC noise floor is significant for your
         application.
     """
-    check_is_fitted(self, attributes=["_vine"])
+    check_is_fitted(self, attributes=["distribution_"])
     X = self._validate_input(X, reset=False)
-    U = self._to_u_scale(X)
     if random_state is None:
       rng = self.random_state_
     else:
@@ -227,7 +233,9 @@ class VineDensity(DensityMixin, VineBase):
 
       rng = check_random_state(random_state)
     seeds = [int(x) for x in rng.randint(0, 2**31 - 1, size=5)]
-    return np.asarray(self.backend_.cdf(self._vine, U, N=N, seeds=seeds))
+    return np.asarray(
+      self.distribution_.cdf(np.asarray(X, dtype=float), N=N, seeds=seeds)
+    )
 
 
 VineDensity.__doc__ = f"""Vine-copula based density estimator.

--- a/src/pyvinecopulib/sklearn/regressor.py
+++ b/src/pyvinecopulib/sklearn/regressor.py
@@ -2,6 +2,7 @@ import numpy as np
 from sklearn.base import RegressorMixin
 from sklearn.utils.validation import check_is_fitted
 
+from ..core import Vinedist
 from ._base import (
   _DOC_DISCRETE,
   _DOC_FACTORIZATION,
@@ -26,6 +27,7 @@ class VineRegressor(RegressorMixin, VineBase):
     mean: bool = True,
     quantiles=None,
     backend=None,
+    margins=None,
     batch_size: int = 100,
     use_grid: bool = True,
     normalize_weights: bool = True,
@@ -52,6 +54,15 @@ class VineRegressor(RegressorMixin, VineBase):
         pre-specified structure on ``(Y, X_1, ..., X_d)`` (`Y`
         always in the first dimension). `None` resolves to a default
         ``VinecopBackend`` with the ``tll`` pair family at fit time.
+    margins : object, default=None
+        The marginal half of the model, in any form
+        :func:`pyvinecopulib.margins.resolve_margins` accepts. `None`
+        fits a ``Kde1dMargin`` per column. The specification addresses
+        the covariates; one that broadcasts (an alias, a single margin,
+        a callable) applies to the response as well. With
+        ``use_grid=True`` the response margin must be a
+        ``Kde1dMargin``, since the quadrature nodes are read off its
+        interpolation grid.
     batch_size : int, default=100
         Number of test points processed per batch in `predict`.
     use_grid : bool, default=True
@@ -59,8 +70,9 @@ class VineRegressor(RegressorMixin, VineBase):
         weighted-sample predictor. ``False`` uses importance
         weighting over training rows with
         :math:`w_i(x) \\propto c_{Y,X}(\\hat F_Y(y_i),
-        \\hat F_X(x))`. ``True`` (default) uses the Kde1d grid
-        points and an extra :math:`\\hat f_Y(y_g)` factor.
+        \\hat F_X(x))`. ``True`` (default) uses the response
+        margin's kernel-density grid points and an extra
+        :math:`\\hat f_Y(y_g)` factor.
     normalize_weights : bool, default=True
         If ``True`` (default), per-row weights produced by
         `_iter_weights` are rescaled to sum to one. Set to
@@ -72,7 +84,10 @@ class VineRegressor(RegressorMixin, VineBase):
         `sklearn.utils.check_random_state` inside `fit`.
     """
     super().__init__(
-      backend=backend, batch_size=batch_size, random_state=random_state
+      backend=backend,
+      margins=margins,
+      batch_size=batch_size,
+      random_state=random_state,
     )
     self.mean = mean
     self.quantiles = quantiles
@@ -121,18 +136,30 @@ class VineRegressor(RegressorMixin, VineBase):
     uy_train = self._to_u_scale(y, is_y=True)
     ux = self._to_u_scale(X)
 
-    assert self.schema_ is not None
-    var_types = ["c"] + [x[0] for x in self.schema_["kde1d_types"]]
+    # The response leads the joint model, and being continuous it adds no
+    # left-limit column, so its `u` column simply prepends to the covariates'
+    # own layout.
+    margins = (self._y_margin, *self._x_margins)
+    var_types = Vinedist.copula_var_types(margins)
     self._fit_vine(np.column_stack([uy_train, ux]), var_types=var_types)
+    self._bind_distribution(margins)
 
     if not self.use_grid:
       self._y_train = y
       self._uy_train = uy_train
     else:
-      self._y_train = self._y_kde1d.grid_points
-      uy_cdf = self._y_kde1d.cdf(self._y_train)
-      self._uy_train = np.asarray(uy_cdf).reshape(-1, 1)
-      self._y_density = self._y_kde1d.values[np.newaxis, :]
+      kde = getattr(self._y_margin, "kde1d", None)
+      if kde is None:
+        raise ValueError(
+          "use_grid=True reads the quadrature nodes off the response "
+          "margin's kernel-density grid, which "
+          f"{type(self._y_margin).__name__} does not have. Pass "
+          "use_grid=False, or leave the response margin on the default "
+          "Kde1dMargin."
+        )
+      self._y_train = np.asarray(kde.grid_points)
+      self._uy_train = self._to_u_scale(self._y_train, is_y=True)
+      self._y_density = np.asarray(kde.values)[np.newaxis, :]
     return self
 
   def _copula_marginal_density(

--- a/tests/test_core_vinedist.py
+++ b/tests/test_core_vinedist.py
@@ -132,6 +132,32 @@ def test_simulate_respects_a_discrete_margin(data: np.ndarray) -> None:
   np.testing.assert_array_equal(drawn[:, 2], np.round(drawn[:, 2]))
 
 
+def test_cdf_accepts_a_margin_with_atoms(data: np.ndarray) -> None:
+  """A copula with atoms validates the whole layout, so the layout is what it
+  gets -- even though a distribution function reads only the first block."""
+  dist = pv.Vinedist.from_data(data, margins=["kde", "kde", stats.poisson(3.0)])
+  values = np.asarray(dist.cdf(data[:20], N=2000, seeds=[1, 2, 3]))
+  assert values.shape == (20,)
+  assert np.all((values >= 0.0) & (values <= 1.0))
+
+
+def test_copula_data_needs_no_copula(data: np.ndarray) -> None:
+  """The layout and the var_types are available before a copula exists."""
+  margins: list[Any] = [
+    Kde1dMargin().fit(data[:, 0]),
+    Kde1dMargin().fit(data[:, 1]),
+    stats.poisson(3.0),
+  ]
+  assert pv.Vinedist.copula_var_types(margins) == ["c", "c", "d"]
+  layout = pv.Vinedist.copula_data(margins, data)
+  assert layout.shape == (data.shape[0], 4)
+
+  # Which is exactly the workflow of fitting your own copula and wrapping it.
+  copula = pv.Vinecop.from_data(layout, var_types=["c", "c", "d"])
+  dist = pv.Vinedist(copula, margins)
+  np.testing.assert_array_equal(layout, dist._u_layout(data))
+
+
 def test_left_limit_above_the_cdf_is_refused() -> None:
   """A margin that reports `F(x^-) > F(x)` is caught at the boundary."""
   from pyvinecopulib.core import MarginBase
@@ -315,6 +341,8 @@ def test_wrong_column_count_is_refused(continuous: np.ndarray) -> None:
   dist = pv.Vinedist.from_data(continuous)
   with pytest.raises(ValueError, match=r"shape \(n, 2\)"):
     dist.logpdf(np.ones((10, 3)))
+  with pytest.raises(ValueError, match=r"shape \(n, 2\)"):
+    pv.Vinedist.copula_data(dist.margins, np.ones((10, 3)))
 
 
 def test_repr_names_the_margin_families(continuous: np.ndarray) -> None:

--- a/tests/test_margins.py
+++ b/tests/test_margins.py
@@ -23,6 +23,7 @@ from pyvinecopulib.margins import (
   Kde1dMargin,
   as_margin,
   register_margin_adapter,
+  resolve_margins,
 )
 
 scipy_stats = pytest.importorskip("scipy.stats")
@@ -200,6 +201,24 @@ def test_kde1d_margin_from_kde1d_requires_a_fitted_estimator(
   kde.fit(sample)
   adopted = Kde1dMargin.from_kde1d(kde)
   assert adopted.is_fitted and adopted.support == (0.0, float("inf"))
+
+
+# --- resolve_margins -------------------------------------------------------- #
+
+
+def test_resolve_margins_falls_back_to_the_given_default() -> None:
+  """An unaddressed variable takes the caller's default, not the library's."""
+  default = [Kde1dMargin(type="discrete"), Kde1dMargin(type="zero-inflated")]
+  resolved = resolve_margins({0: EmpiricalMargin()}, 2, default=default)
+  assert isinstance(resolved[0], EmpiricalMargin)
+  assert resolved[1].type == "zero-inflated"
+  assert resolve_margins(None, 2, default=default)[0].type == "discrete"
+
+
+def test_resolve_margins_checks_the_default_length() -> None:
+  """A default is per variable, so its length is checked like a sequence's."""
+  with pytest.raises(ValueError, match="default has length 1"):
+    resolve_margins(None, 2, default=[Kde1dMargin()])
 
 
 # --- as_margin -------------------------------------------------------------- #

--- a/tests/test_sklearn_backends.py
+++ b/tests/test_sklearn_backends.py
@@ -214,7 +214,10 @@ class TestEstimatorWiring:
 
   def test_fit_sets_schema_underscore(self, small_data):
     est = VineDensity().fit(small_data)
-    assert est.schema_ == {"kde1d_types": ["continuous"] * 3}
+    assert est.schema_ == {
+      "kde1d_types": ["continuous"] * 3,
+      "bounds": [None] * 3,
+    }
 
   def test_fit_sets_structure_underscore(self, small_data):
     est = VineDensity().fit(small_data)

--- a/tests/test_sklearn_base.py
+++ b/tests/test_sklearn_base.py
@@ -158,6 +158,12 @@ def test_vinebase_schema_attribute(
   with pytest.raises(ValueError):
     density_wrong._validate_input(X, reset=True)
 
+  # So does a pre-set bounds list of the wrong length.
+  density_bounds = VineDensity()
+  density_bounds.schema_ = {"bounds": [(0.0, 1.0)]}  # Too short
+  with pytest.raises(ValueError, match="bounds"):
+    density_bounds._validate_input(X, reset=True)
+
 
 def test_vinebase_marginal_fitting(
   sample_array_data: tuple[np.ndarray, np.ndarray, np.ndarray],
@@ -170,9 +176,8 @@ def test_vinebase_marginal_fitting(
   density._fit_marginals(X_processed)
 
   # Check that marginals are fitted
-  assert len(density._x_kde1d) == 2
-
-  assert all(hasattr(kde, "fit") for kde in density._x_kde1d)
+  assert len(density._x_margins) == 2
+  assert all(margin.is_fitted for margin in density._x_margins)
 
 
 def test_vinebase_pseudoobservations(

--- a/tests/test_sklearn_check_estimator.py
+++ b/tests/test_sklearn_check_estimator.py
@@ -6,7 +6,7 @@ opted out of. The skip list captures two categories:
 
 - **Genuine opt-outs**: checks that don't apply to a joint-density /
   vine-regressor archetype (sparse inputs, 1-D / 1-feature degenerate
-  cases, complex-valued data, etc.).
+  cases, etc.).
 - **Known WIP**: checks that surface real sklearn-compliance gaps the
   initial backend-refactor PR did not fix. Listed with ``TODO``
   comments so future PRs can address them and shrink this list.
@@ -50,9 +50,7 @@ _GENUINE_OPT_OUTS = {
   "check_fit2d_1sample": "Kde1d requires >= 2 samples to estimate a bandwidth",
   "check_fit1d": "vines require 2-D U-scale data",
   "check_fit2d_predict1d": "predict requires 2-D inputs",
-  "check_complex_data": "complex inputs not supported",
   "check_estimators_dtypes": "internal float64 promotion is intentional",
-  "check_dtype_object": "internal float64 promotion is intentional",
   "check_estimators_empty_data_messages": (
     "empty data error messages — TODO: surface a sklearn-shaped error early"
   ),

--- a/tests/test_sklearn_density.py
+++ b/tests/test_sklearn_density.py
@@ -51,9 +51,9 @@ def test_fit_properties(fitted_density):
   """Test properties after fitting."""
   density, _ = fitted_density
   assert hasattr(density, "_vine")
-  assert hasattr(density, "_x_kde1d")
   assert density.n_features_in_ == 2
-  assert len(density._x_kde1d) == 2
+  assert density.distribution_.dim == 2
+  assert len(density.distribution_.margins) == 2
 
 
 def test_score_samples_shapes_and_types(fitted_density):

--- a/tests/test_sklearn_margins.py
+++ b/tests/test_sklearn_margins.py
@@ -1,0 +1,316 @@
+"""Tests for the ``margins=`` half of the sklearn estimators.
+
+What this file pins is the delegation. That an estimator *is* a `Vinedist` --
+the same layout, the same log-density, the same draws -- rather than a second
+implementation of Sklar's theorem that can drift from the first. That
+`margins=None` still means what it meant before margins were configurable: a
+`Kde1d` per column, to the last bit. That a specification the caller gives is
+honored per column and never mutated, so `clone` reproduces the estimator. And
+that the ``{0, 1}`` dummies of an expanded unordered categorical are fitted on
+the support they actually have, rather than on a padded grid that puts mass on
+values that cannot occur.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+pytest.importorskip("sklearn")
+pytest.importorskip("pandas")
+
+import pandas as pd  # noqa: E402  (import order: after the availability check)
+
+from sklearn.base import clone  # noqa: E402
+
+import pyvinecopulib as pv  # noqa: E402
+from pyvinecopulib.margins import (  # noqa: E402
+  EmpiricalMargin,
+  Kde1dMargin,
+  MarginSelector,
+)
+from pyvinecopulib.sklearn import VineDensity, VineRegressor  # noqa: E402
+
+# --- the default is the old pipeline ---------------------------------------- #
+
+
+def test_default_margins_reproduce_the_kde1d_pipeline(
+  sample_array_data: tuple[np.ndarray, np.ndarray, np.ndarray],
+) -> None:
+  """`margins=None` is the pre-margins pipeline, to floating-point rounding."""
+  X, _, _ = sample_array_data
+  eps = 1e-10
+  kdes = []
+  for j in range(X.shape[1]):
+    kde = pv.utils.Kde1d()
+    kde.fit(X[:, j])
+    kdes.append(kde)
+
+  def transform(z: np.ndarray) -> np.ndarray:
+    return np.column_stack(
+      [np.clip(k.cdf(z[:, j]), eps, 1 - eps) for j, k in enumerate(kdes)]
+    )
+
+  vine = pv.Vinecop.from_data(
+    data=transform(X),
+    var_types=["c"] * X.shape[1],
+    controls=pv.FitControlsVinecop(
+      family_set=[pv.families.tll], trunc_lvl=20, num_threads=1
+    ),
+  )
+  head = X[:20]
+  expected = np.log(np.asarray(vine.pdf(transform(head)))) + sum(
+    np.log(np.asarray(kdes[j].pdf(head[:, j]))) for j in range(X.shape[1])
+  )
+  got = VineDensity().fit(X).score_samples(head)
+  np.testing.assert_allclose(got, expected, rtol=1e-12, atol=1e-14)
+
+
+# --- the fitted distribution ------------------------------------------------ #
+
+
+def test_fit_publishes_the_distribution(
+  sample_array_data: tuple[np.ndarray, np.ndarray, np.ndarray],
+) -> None:
+  """`distribution_` is the fitted model, and agrees with the estimator."""
+  X, _, _ = sample_array_data
+  est = VineDensity().fit(X)
+  assert isinstance(est.distribution_, pv.Vinedist)
+  assert est.distribution_.dim == est.n_features_in_
+  np.testing.assert_allclose(est.distribution_.pdf(X[:10]), est.pdf(X[:10]))
+  np.testing.assert_allclose(
+    est.distribution_.simulate(5, seeds=[1, 2, 3]).shape, (5, 2)
+  )
+
+
+def test_the_held_copula_still_answers_as_the_vine(
+  sample_array_data: tuple[np.ndarray, np.ndarray, np.ndarray],
+) -> None:
+  """Wrapping the vine for the backend does not hide the vine's own surface."""
+  X, _, _ = sample_array_data
+  est = VineDensity().fit(X)
+  copula = est.distribution_.copula
+  assert copula.dim == est.n_features_in_
+  assert copula.var_types == ["c", "c"]
+  np.testing.assert_array_equal(
+    np.asarray(copula.structure.matrix), np.asarray(est.structure_.matrix)
+  )
+  np.testing.assert_allclose(
+    np.asarray(copula.pdf(est._to_u_scale(X[:10]))),
+    est.pdf(X[:10], copula_only=True),
+  )
+
+
+def test_joint_distribution_of_the_regressor_leads_with_the_response(
+  regression_data: tuple[np.ndarray, np.ndarray, np.ndarray, float],
+) -> None:
+  """The regressor's distribution is over ``(Y, X)``, the response first."""
+  X, y, _, _ = regression_data
+  est = VineRegressor().fit(X, y)
+  assert est.distribution_.dim == X.shape[1] + 1
+  np.testing.assert_allclose(
+    est.distribution_.logpdf(np.column_stack([y[:10], X[:10]])),
+    est._pdf_samples(X[:10], y=y[:10], log=True),
+  )
+
+
+# --- bounds of an expanded dummy -------------------------------------------- #
+
+
+def test_expanded_dummies_are_fitted_on_their_own_support(
+  sample_dataframe_data: tuple[pd.DataFrame, list[str]],
+) -> None:
+  """A ``{0, 1}`` dummy is bounded, so no mass lands on an impossible value."""
+  X_df, expanded = sample_dataframe_data
+  est = VineDensity().fit(X_df)
+  dummies = [j for j, name in enumerate(expanded) if name.startswith("cat1_")]
+  assert dummies
+  for j in dummies:
+    # `support` / `var_type` / `is_fitted` are optional capabilities, not
+    # members of `MarginLike`, so they are read off a loosely typed binding.
+    margin: Any = est.distribution_.margins[j]
+    assert margin.support == (0.0, 1.0)
+    assert margin.pdf(np.array([2.0])).item() == 0.0
+    assert margin.cdf(np.array([-1.0])).item() == 0.0
+  # The bounds of any other column are the caller's to declare, not ours.
+  unbounded: Any = est.distribution_.margins[0]
+  assert unbounded.support == (-np.inf, np.inf)
+
+
+def test_cdf_works_with_columns_that_have_atoms(
+  sample_dataframe_data: tuple[pd.DataFrame, list[str]],
+) -> None:
+  """A copula with atoms validates the whole layout, and gets it."""
+  X_df, _ = sample_dataframe_data
+  est = VineDensity(random_state=0).fit(X_df)
+  values = est.cdf(X_df.iloc[:10])
+  assert values.shape == (10,)
+  assert np.all((values >= 0.0) & (values <= 1.0))
+
+
+def test_sample_returns_the_expanded_feature_space(
+  sample_dataframe_data: tuple[pd.DataFrame, list[str]],
+) -> None:
+  """Dummies come back as columns: collapsing them is not an inverse."""
+  X_df, expanded = sample_dataframe_data
+  est = VineDensity(random_state=0).fit(X_df)
+  drawn = est.sample(20, random_state=1)
+  assert drawn.shape == (20, len(expanded))
+  j = expanded.index("cat1_B")
+  assert set(np.unique(drawn[:, j])) <= {0.0, 1.0}
+
+
+# --- specifications --------------------------------------------------------- #
+
+
+def test_fit_does_not_mutate_the_margins_argument(
+  sample_array_data: tuple[np.ndarray, np.ndarray, np.ndarray],
+) -> None:
+  """Specifications are fitted on copies, so the parameters survive `fit`."""
+  X, _, _ = sample_array_data
+  spec = Kde1dMargin()
+  est = VineDensity(margins=spec).fit(X)
+  assert est.get_params()["margins"] is spec
+  assert not spec.is_fitted
+  fitted: tuple[Any, ...] = est.distribution_.margins
+  assert all(margin.is_fitted for margin in fitted)
+  # Refitting therefore re-estimates rather than reusing the first fit.
+  est.fit(X[:100])
+  assert not spec.is_fitted
+
+
+def test_clone_round_trips_the_margins_parameter(
+  sample_array_data: tuple[np.ndarray, np.ndarray, np.ndarray],
+) -> None:
+  """`clone` reproduces an estimator that fits the same margins."""
+  X, _, _ = sample_array_data
+  est = VineDensity(margins="empirical").fit(X)
+  cloned = clone(est)
+  assert cloned.margins == "empirical"
+  np.testing.assert_allclose(
+    cloned.fit(X).score_samples(X[:10]), est.score_samples(X[:10])
+  )
+
+
+def test_a_wrong_length_sequence_is_refused(
+  sample_array_data: tuple[np.ndarray, np.ndarray, np.ndarray],
+) -> None:
+  """A per-column sequence must carry one entry per column."""
+  X, _, _ = sample_array_data
+  with pytest.raises(ValueError, match="length 1, but there are 2"):
+    VineDensity(margins=[Kde1dMargin()]).fit(X)
+
+
+def test_a_mapping_leaves_the_other_columns_on_the_inferred_default(
+  sample_dataframe_data: tuple[pd.DataFrame, list[str]],
+) -> None:
+  """Addressing one column must not silently retype the rest."""
+  X_df, expanded = sample_dataframe_data
+  est = VineDensity(margins={"cont1": EmpiricalMargin()}).fit(X_df)
+  margins = est.distribution_.margins
+  assert isinstance(margins[0], EmpiricalMargin)
+  dummy: Any = margins[expanded.index("cat1_B")]
+  assert isinstance(dummy, Kde1dMargin)
+  assert dummy.var_type == "d"
+  assert dummy.support == (0.0, 1.0)
+
+
+def test_a_preset_schema_supplies_what_an_array_cannot_carry() -> None:
+  """`schema_` declares per-column variable types and bounds before `fit`."""
+  rng = np.random.default_rng(0)
+  X = np.column_stack([rng.poisson(3.0, size=200) * 1.0, rng.normal(size=200)])
+  est = VineDensity()
+  est.schema_ = {
+    "kde1d_types": ["discrete", "continuous"],
+    "bounds": [(0.0, 20.0), None],
+  }
+  est.fit(X)
+  counts: Any = est.distribution_.margins[0]
+  assert counts.var_type == "d"
+  assert counts.support == (0.0, 20.0)
+  assert est.distribution_.var_types == ["d", "c"]
+
+
+def test_a_fixed_foreign_margin_is_used_as_given(
+  sample_array_data: tuple[np.ndarray, np.ndarray, np.ndarray],
+) -> None:
+  """An already-fitted margin is not re-estimated."""
+  stats = pytest.importorskip("scipy.stats")
+  X, _, _ = sample_array_data
+  est = VineDensity(margins=[stats.norm(0.0, 1.0), stats.norm(0.0, 1.0)]).fit(X)
+  np.testing.assert_allclose(
+    np.asarray(est.distribution_.margins[0].cdf(np.array([0.0]))), 0.5
+  )
+
+
+# --- family selection ------------------------------------------------------- #
+
+
+def test_selection_report_is_empty_without_a_selector(
+  sample_array_data: tuple[np.ndarray, np.ndarray, np.ndarray],
+) -> None:
+  """Nothing selected a family, so the table is empty rather than absent."""
+  X, _, _ = sample_array_data
+  assert VineDensity().fit(X).selection_report_ == []
+
+
+def test_parametric_margins_report_their_selection(
+  sample_array_data: tuple[np.ndarray, np.ndarray, np.ndarray],
+) -> None:
+  """`margins="parametric"` selects per column and names the column it fitted."""
+  pytest.importorskip("scipy")
+  X, _, _ = sample_array_data
+  est = VineDensity(margins="parametric").fit(X)
+  assert all(isinstance(m, MarginSelector) for m in est.distribution_.margins)
+  assert {row["column"] for row in est.selection_report_} == {"x0", "x1"}
+  assert "selected" in {row["status"] for row in est.selection_report_}
+
+
+def test_selection_report_names_dataframe_columns(
+  sample_dataframe_data: tuple[pd.DataFrame, list[str]],
+) -> None:
+  """With named features, the report is keyed by the expanded column name."""
+  pytest.importorskip("scipy")
+  X_df, expanded = sample_dataframe_data
+  est = VineDensity(margins="parametric").fit(X_df)
+  assert {row["column"] for row in est.selection_report_} == set(expanded)
+
+
+# --- the response margin ---------------------------------------------------- #
+
+
+def test_the_response_margin_follows_a_broadcast_specification(
+  regression_data: tuple[np.ndarray, np.ndarray, np.ndarray, float],
+) -> None:
+  """An alias covers the response too; a per-column sequence does not."""
+  X, y, _, _ = regression_data
+  broadcast = VineRegressor(margins="empirical", use_grid=False).fit(X, y)
+  assert isinstance(broadcast.distribution_.margins[0], EmpiricalMargin)
+
+  per_column = VineRegressor(
+    margins=[EmpiricalMargin(), EmpiricalMargin()]
+  ).fit(X, y)
+  assert isinstance(per_column.distribution_.margins[0], Kde1dMargin)
+  assert isinstance(per_column.distribution_.margins[1], EmpiricalMargin)
+
+
+def test_use_grid_needs_a_kernel_density_response(
+  regression_data: tuple[np.ndarray, np.ndarray, np.ndarray, float],
+) -> None:
+  """The quadrature nodes come off the response margin's grid, so say so."""
+  X, y, _, _ = regression_data
+  with pytest.raises(ValueError, match="use_grid=True"):
+    VineRegressor(margins="empirical").fit(X, y)
+
+
+def test_a_discrete_response_margin_is_refused(
+  regression_data: tuple[np.ndarray, np.ndarray, np.ndarray, float],
+) -> None:
+  """The joint layout leads with the response and gives it no left limit."""
+  X, y, _, _ = regression_data
+  with pytest.raises(ValueError, match="response margin must be continuous"):
+    VineRegressor(margins=Kde1dMargin(type="discrete"), use_grid=False).fit(
+      X, np.round(y)
+    )

--- a/tests/test_sklearn_regressor.py
+++ b/tests/test_sklearn_regressor.py
@@ -36,10 +36,10 @@ def test_fit_properties(fitted_regressor):
   """Test properties after fitting."""
   regressor, _, _, _, _, _ = fitted_regressor
   assert hasattr(regressor, "_vine")
-  assert hasattr(regressor, "_x_kde1d")
-  assert hasattr(regressor, "_y_kde1d")
   assert hasattr(regressor, "_y_train")
   assert regressor.n_features_in_ == 2
+  # The joint distribution is over (Y, X), the response first.
+  assert regressor.distribution_.dim == 3
 
 
 def test_predict_mean_only(regression_setup):


### PR DESCRIPTION
Stacked on #279 (`feat/margins-parametric`). PR 9 of the vine-distribution stack.

## What this does

`sklearn/_base.py` was the only place in the library that assembled a full
multivariate distribution, and it did so by hand against a hardcoded `Kde1d`:
one KDE per column in `_fit_marginals`, the `F(x)` / `F(x^-)` layout and its
clamp in `_to_u_scale`, `log c(u) + Σ log f_j` in `_pdf_samples`, and the only
inverse transform in `VineDensity.sample`. `core.Vinedist` now does all four.
This PR replaces the duplicate with delegation, and makes the marginal half
configurable in the same move.

- **`margins=` on both estimators**, stored verbatim (no validation in
  `__init__`), listed in `_parameter_constraints`, resolved by
  `margins.resolve_margins`. Anything that function accepts works: an alias
  (`"kde"`, `"empirical"`, `"parametric"`), one margin broadcast, a per-column
  sequence, a mapping keyed by expanded feature name or position, a callable, or
  a fixed foreign distribution (`scipy.stats.norm(0, 1)`).
- **`distribution_`**, a `Vinedist`, and **`selection_report_`**, the
  per-candidate table of any margin that selected its own family (keyed by
  expanded column name). Every post-fit method now evaluates through
  `distribution_`.
- `_fit_marginals` / `_to_u_scale` / `_pdf_samples` are thin delegations;
  `_x_kde1d` / `_y_kde1d` are gone.

## Reasoning and trade-offs

**The default had to stay faithful, and it is.** `margins=None` builds a
`Kde1dMargin` per column with `Kde1d`'s own defaults and the variable type the
input implies, so nothing about the fit changes. Per the maintainer no parity
harness was required, so instead of a framework there is one test that
transcribes the previous pipeline and compares `score_samples` (agrees to
4.4e-16, i.e. log-summation order), plus a local check that the fitted vine
matrix is identical and that the regressor's `use_grid=True` predictions are
bit-identical to the pre-refactor grid path.

**`distribution_` holds the vine wrapped in a private `_BackendVinecop`, not
the raw vine.** `Vinedist` calls `copula.pdf(u)` directly, which would drop
`num_threads` on the default backend and — worse — return a CUDA tensor that
the NumPy margin terms cannot be combined with on `TorchVinecopBackend`. The
wrapper routes `pdf` / `cdf` / `simulate` through the backend (keeping its
arguments and its NumPy conversion) and forwards every other attribute to the
vine, so `distribution_.copula` still answers `dim` / `var_types` / `structure`
and pickles. The alternative — keeping the log-sum in sklearn — would have left
two implementations of the thing this PR exists to unify.

**Two new public statics on `Vinedist`: `copula_data` and `copula_var_types`.**
The sklearn layer fits its copula through a backend, so it cannot go through
`Vinedist.from_data`, and the layout plus the `var_types` have to exist before
the copula does. Rather than re-implement either (the whole point of the PR),
they are lifted out of `_u_layout` as statics over a set of margins. That also
makes "fit your own copula, then wrap it" a documented workflow, and it deletes
`from_data`'s `object.__new__` stub. Slightly beyond the files the plan listed
for this PR; the alternative was duplicating the layout builder in sklearn.

**`resolve_margins` takes `default=`** (one specification per variable). The
estimators know per column what the library cannot — the variable type, and the
bounds of an expanded dummy — and without this a mapping addressing one column
would silently retype every other one to a plain continuous KDE.

**`VineRegressor` needed decisions the plan does not make.** A specification
that broadcasts (alias / single margin / callable) also covers the response, so
`margins="parametric"` means what it looks like; a per-variable one says nothing
about the response and leaves it on the default. Two conditions are checked at
fit time with a message naming the fix rather than failing obscurely later: the
response margin must be continuous (the joint model leads with it and gives it
no left-limit column, which every prediction path assumes), and `use_grid=True`
requires a `Kde1dMargin` response because the quadrature nodes are read off its
interpolation grid. PR 10 (§5.6b) removes the second by moving the quadrature
into probability space; doing it here would preempt that PR and its numerical
check.

## Defects fixed

1. **Expanded dummies were fitted unbounded** (the one named in the task).
   `expand_factors` produces `{0, 1}` columns whose support is known exactly,
   but no bounds were passed, so the KDE padded its grid past the data:
   measured `cdf(-1) = 2.8e-07` and `pdf(2) = 3.5e-07` on a dummy column. They
   now carry `xmin=0, xmax=1`, recorded in `schema_["bounds"]` (a new key; a
   caller-set `schema_` may still supply only `kde1d_types`). Bounds for any
   other discrete column stay unset — including ordered categoricals, whose
   dtype does enumerate the domain but whose unobserved extreme levels would
   change the boundary correction. That is the caller's assumption to make.
2. **`Vinedist.cdf` raised for any margin with atoms.** `Vinecop::cdf` reads
   only the first `d` columns but validates the whole layout, so passing
   `marginal_cdf(x)` was a hard error (`data has wrong number of columns`)
   for every discrete model. It now passes the layout; the numbers on
   continuous models are unchanged. Regression test in
   `tests/test_core_vinedist.py`.
3. **Complex `X` / `y` reached the marginal fit**, where this PR's float
   coercion would have dropped the imaginary part in silence. Rejected in
   `_validate_input` instead — which is why `check_complex_data` and
   `check_dtype_object` leave the `parametrize_with_checks` opt-out table (both
   now pass for both estimators, for the right reason: the coercion error names
   the offending value).

## Left undone, deliberately

- **`VineDensity.sample` still returns the expanded feature space.** The task
  allowed leaving this if de-expansion is not contained, and it is not: a vine
  draw can put a `1` in two dummies of the same categorical at once, so
  inverting `expand_factors` needs a tie-break rule — a modeling decision, not
  a mechanical inverse. The behavior is now documented in the docstring
  instead of being a surprise.
- **No notebook change.** `nbsphinx_execute = "never"`, so an added cell either
  renders empty or forces a re-execution that rewrites every stored output in
  `examples/08_sklearn_estimators.ipynb`. The plan's PR 12 owns the docs and
  ships `examples/11_vine_distributions.ipynb`; the rendered API surface (both
  estimator docstrings and the subpackage docstring) is updated here.
- **No `AGENTS.md` update.** Nothing in this stack has touched it yet (the
  `margins` subpackage, `Vinedist` and `MarginLike` are all still missing from
  it); doing the sklearn corner alone would conflict with that pass.
- **`(#NNN)` on the CHANGELOG bullets**, omitted to match #278 and #279 in this
  stack, which also carry none.

## Verification

All CPU-pinned (`CUDA_VISIBLE_DEVICES=""`).

- `make check` (ruff + format + bandit + codespell + ty): clean.
- `pre-commit run --all-files` (adds numpydoc validation): clean.
- `make docs` after `rm -rf docs/_generate docs/_build` (`-W`, nitpicky): clean.
- `pytest tests/`: **619 passed, 22 xfailed, 96% coverage** (was 592 / 26 / 96%).
  The counts move for two reasons and no others: 23 new tests (18 in the new
  `tests/test_sklearn_margins.py`, 3 in `test_core_vinedist.py`, 2 in
  `test_margins.py`), and 4 previously-xfailed sklearn checks that now pass
  (`check_complex_data` and `check_dtype_object`, on both estimators). No
  tolerance was widened. `core/vinedist.py` and `sklearn/_base.py` coverage:
  every line this PR adds is covered; the remaining misses are the same
  pre-existing paths as before.
- Also checked by hand: pickle round-trips for both estimators on both
  backends, and `TorchVinecopBackend` (CPU) `pdf` / `cdf` / `sample` /
  `distribution_.pdf`.
