### PR TITLE
fix(margins): reproducible discrete fits, and let EmpiricalMargin simulate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,8 @@
 - Fit the `{0, 1}` dummies of an expanded unordered categorical on `[0, 1]` in the sklearn estimators. Their bounds are known exactly, but were never passed, so the kernel-density grid was padded past the data and put mass on values that cannot occur.
 - `Vinedist.cdf` hands the copula the full `(n, d + k)` layout. A distribution function needs only the marginal `F` values and the copula reads only those, but it validates the whole layout, so a margin with atoms made `cdf` raise.
 - Reject complex `X` / `y` in the sklearn estimators rather than casting each column to float and dropping the imaginary part in silence.
+- Pin the RNG of the discrete `ParametricMargin` fitter. `scipy.stats.fit` optimizes with an unseeded `differential_evolution`, so the same counts gave a different parameter vector -- and a different `MarginSelector.report_` -- on every call (#287).
+- `EmpiricalMargin.simulate` works instead of raising `NotImplementedError`, resampling observed values as its documentation already described. Only the standalone call was affected; `Vinedist.simulate` goes through `marginal_icdf` (#287).
 
 ### Dependency changes
 

--- a/src/pyvinecopulib/margins/empirical.py
+++ b/src/pyvinecopulib/margins/empirical.py
@@ -203,6 +203,24 @@ class EmpiricalMargin(MarginBase[np.ndarray]):
     idx = np.searchsorted(self._cum, targets, side="left")
     return values[np.clip(idx, 0, values.size - 1)]
 
+  def _simulate_uniform(self, n: int, seeds: list[int]) -> np.ndarray:
+    """Draw ``n`` uniforms for the inherited ``simulate``.
+
+    Parameters
+    ----------
+    n : int
+        Number of draws.
+    seeds : list of int
+        RNG seeds.
+
+    Returns
+    -------
+    array, shape (n,), dtype float
+        Uniforms in ``(0, 1)``.
+    """
+    rng = np.random.default_rng(seeds if seeds else None)
+    return rng.uniform(size=n)
+
   def __repr__(self) -> str:
     state = f"n={int(self._total)}" if self.is_fitted else "unfitted"
     return f"EmpiricalMargin({state})"

--- a/src/pyvinecopulib/margins/parametric.py
+++ b/src/pyvinecopulib/margins/parametric.py
@@ -115,6 +115,38 @@ def _stats() -> Any:
   return stats
 
 
+#: Seed pinned into the discrete fitter. ``scipy.stats.fit`` optimizes with
+#: ``differential_evolution``, which is stochastic, so an unseeded call returns a
+#: different parameter vector -- and a different ``report_`` row -- every time it
+#: runs on the same data.
+_DISCRETE_FIT_SEED = 5489
+
+
+def _seeded_optimizer(objective: Any, **kwargs: Any) -> Any:
+  """Optimize as ``scipy.stats.fit`` does, with the RNG pinned.
+
+  Parameters
+  ----------
+  objective : callable
+      The negative log-likelihood, as ``scipy.stats.fit`` builds it.
+  **kwargs
+      The remaining arguments ``scipy.stats.fit`` supplies, ``bounds`` and
+      ``integrality``.
+
+  Returns
+  -------
+  scipy.optimize.OptimizeResult
+      The optimizer result, carrying ``x`` and ``fun``.
+  """
+  import importlib
+  import inspect
+
+  de = importlib.import_module("scipy.optimize").differential_evolution
+  # `seed` was renamed to `rng` across the supported SciPy range.
+  key = "rng" if "rng" in inspect.signature(de).parameters else "seed"
+  return de(objective, **{key: _DISCRETE_FIT_SEED}, **kwargs)
+
+
 def _curated_margin(
   family: str,
   partition: str,
@@ -522,7 +554,9 @@ class ParametricMargin(MarginBase[np.ndarray]):
         search[name] = (value, value)
       else:
         search[name] = self._bounds[name]
-    result = _stats().fit(self._dist, data, bounds=search)
+    result = _stats().fit(
+      self._dist, data, bounds=search, optimizer=_seeded_optimizer
+    )
     return tuple(float(v) for v in result.params)
 
   # --- evaluation ---------------------------------------------------------- #

--- a/tests/test_margins.py
+++ b/tests/test_margins.py
@@ -54,6 +54,18 @@ def test_empirical_margin_reproduces_to_pseudo_obs(sample: np.ndarray) -> None:
   np.testing.assert_array_equal(got, want)
 
 
+def test_empirical_margin_simulates_by_resampling(
+  sample: np.ndarray,
+) -> None:
+  """`icdf` is a step function, so draws are observed values and nothing else."""
+  m = EmpiricalMargin().fit(sample)
+  draws = m.simulate(64, seeds=[7])
+  assert draws.shape == (64,)
+  assert np.isin(draws, np.unique(sample)).all()
+  np.testing.assert_array_equal(draws, m.simulate(64, seeds=[7]))
+  assert not np.array_equal(draws, m.simulate(64, seeds=[8]))
+
+
 def test_empirical_margin_saturates_off_the_boundary(
   sample: np.ndarray,
 ) -> None:

--- a/tests/test_margins_parametric.py
+++ b/tests/test_margins_parametric.py
@@ -90,6 +90,20 @@ def test_parametric_margin_logpdf_beats_log_of_pdf() -> None:
     assert not np.isfinite(np.log(m.pdf(far))).all()
 
 
+def test_discrete_fit_is_reproducible(count_sample: np.ndarray) -> None:
+  """`scipy.stats.fit` optimizes stochastically; the seed makes it repeatable.
+
+  Without a pinned RNG the same counts give a different parameter vector on
+  every call, which makes a `MarginSelector` count-group `report_` differ run
+  to run.
+  """
+  fits = [
+    ParametricMargin("nbinom").fit(count_sample).parameters for _ in range(3)
+  ]
+  for other in fits[1:]:
+    np.testing.assert_array_equal(fits[0], other)
+
+
 def test_parametric_margin_pins_the_discrete_lattice_offset(
   count_sample: np.ndarray,
 ) -> None:


### PR DESCRIPTION
Stacked on #286. Two defects that writing the example notebook against the real API turned up.

## 1. Discrete parametric fits were not reproducible

`ParametricMargin._fit_discrete` called

```python
result = _stats().fit(self._dist, data, bounds=search)
```

`scipy.stats.fit`'s default optimizer is `differential_evolution`, which is stochastic and was left unseeded. Measured on 800 negative-binomial counts, three consecutive fits of the same data:

| run | `n` | log-likelihood |
|---|---|---|
| 1 | 760 | -1472.497 |
| 2 | 423 | -1472.431 |
| 3 | 239 | -1472.323 |

An AIC spread of ~0.35 — enough in principle to reverse a close comparison, and more than enough to make a `MarginSelector`'s count-group `report_` differ run to run, which defeats the purpose of shipping a report at all. Continuous families were never affected: they go through SciPy's deterministic analytic `.fit()`, not `stats.fit`.

The optimizer is now wrapped with its RNG pinned. `differential_evolution` renamed `seed` to `rng` inside the supported SciPy range (`scipy>=1.15`), so the keyword is picked from the signature rather than assumed. After the fix the same three fits return bit-identical parameters:

```
nbinom fit 0 : (4.0, 0.347977, 0.0)
nbinom fit 1 : (4.0, 0.347977, 0.0)
nbinom fit 2 : (4.0, 0.347977, 0.0)
```

**Note on what this does and does not fix.** `nbinom`'s `n` is weakly identified on data close to its Poisson limit (`n → ∞`, `p → 1`) — the same non-identifiability that kept `binom` out of `_PARTITIONS`. Its *log-likelihood* is well behaved, so selection is sound, but its reported `n` is loosely determined by the data. Pinning the seed makes that reproducible rather than making it go away; I left `nbinom` in the curated set because overdispersed counts are exactly what it is for, and the alternative is having no count family beyond Poisson.

## 2. `EmpiricalMargin.simulate()` raised

`EmpiricalMargin` never overrode `_simulate_uniform`, so the inherited `simulate` hit `MarginBase`'s raising default — while the class Notes say the opposite:

> `icdf` is a step function, so simulating through this margin resamples observed values and never produces a new one.

That describes working behavior. It was the only shipped NumPy margin that could not simulate (`Kde1dMargin`, `ParametricMargin` and `MarginSelector` all override `simulate` directly).

Why no test caught it: `Vinedist.simulate` is `marginal_icdf(copula.inverse_rosenblatt(w))` and never calls a margin's own sampler, so a `Vinedist` with empirical margins works fine — only the standalone call was broken.

The fix overrides `_simulate_uniform` rather than `simulate`, which is what makes the documented semantics literally true: the inherited `simulate` is `icdf(U)`, and `icdf` being a step function is precisely why the draws are resampled observations.

## Verification

All CPU-pinned (`CUDA_VISIBLE_DEVICES=""`), targeted files only — no whole-suite run.

```
uv run --no-sync pytest tests/test_margins.py tests/test_margins_parametric.py \
  tests/test_core_vinedist.py tests/test_core_margin_base.py \
  tests/test_sklearn_margins.py tests/test_pickling.py -q   # 148 passed
ruff check / ruff format / bandit / ty                       # all pass (pre-commit)
```

Two tests added, each pinning the property rather than the implementation:

- `test_empirical_margin_simulates_by_resampling` — draws are all observed values, the same `seeds` reproduce them, and different `seeds` do not.
- `test_discrete_fit_is_reproducible` — three fits of the same counts are `assert_array_equal`. This fails on the parent commit.
