### PR TITLE
feat(core): report family selection from Vinedist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@
 - Add `Vinedist.copula_data` and `Vinedist.copula_var_types`: from a set of margins, the copula-scale layout for some data and the `var_types` a copula must be fitted with. That is what "fit your own copula, then wrap it" needs, and what the sklearn estimators use.
 - `resolve_margins` takes `default=`, one specification per variable, so a caller that knows something per variable keeps it for the variables a mapping does not address.
 - Document vine distributions: a `concepts.rst` section on the `{pdf, cdf, icdf}` margin contract, why `pdf` is the density with respect to the margin's own reference measure (so the Sklar factorization needs no branch on variable type), and what the two-step estimator costs; plus `examples/11_vine_distributions.ipynb`, worked on data with known margins so each estimate is checked against a truth (#286).
+- Add `Vinedist.selection_report`, the per-candidate family-selection rows across every margin that selected, labeled by variable. `Vinedist.from_data` reads a DataFrame's column names when none are given, so `margins=` may be a mapping keyed by name, and labels each selector with its variable so the report rows are distinguishable (#288).
 
 ### Build / packaging
 

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -629,7 +629,9 @@ alone. So ``st.norm(0, 1)`` above stays exactly :math:`N(0, 1)` while
 ``MarginSelector`` estimates its family from the ``income`` column.
 
 :class:`pyvinecopulib.margins.MarginSelector` fits every admissible
-candidate and keeps the best by AIC, BIC or AICc, reporting the rest.
+candidate and keeps the best by AIC, BIC or AICc, reporting the rest;
+:meth:`pyvinecopulib.core.Vinedist.selection_report` collects those rows across
+every variable, labeled by the variable each was fitted to.
 Two choices in it are deliberate. The candidate set is **curated and
 partitioned by support**, not "every family in SciPy": an unconstrained
 sweep is actively misleading, because a family whose reported support is

--- a/src/pyvinecopulib/core/vinedist.py
+++ b/src/pyvinecopulib/core/vinedist.py
@@ -2,11 +2,41 @@
 
 from __future__ import annotations
 
+import copy
 from typing import Any, Generic, Optional, Sequence, cast
 
 from array_api_compat import array_namespace
 
 from .protocols import ArrayT, MarginLike
+
+
+def _named(spec: Any, name: Optional[str]) -> Any:
+  """Label a selecting margin with the variable it is fitted to.
+
+  A selector records the variable on each row of its report; without this the
+  rows of a multi-variable report are indistinguishable.
+
+  Parameters
+  ----------
+  spec : object
+      A margin specification.
+  name : str, or None
+      The variable's name, or ``None`` when the data carry none.
+
+  Returns
+  -------
+  object
+      The specification, labeled. Only a nameless selector is copied and
+      relabeled, so a specification the caller still holds is left untouched.
+  """
+  if name is None or not hasattr(spec, "report_"):
+    return spec
+  if getattr(spec, "name", "") is not None:
+    return spec
+  spec = copy.deepcopy(spec)
+  spec.name = name
+  return spec
+
 
 __all__ = ["Vinedist"]
 
@@ -161,6 +191,25 @@ class Vinedist(Generic[ArrayT]):
         One margin per variable.
     """
     return self._margins
+
+  def selection_report(self) -> list[dict[str, Any]]:
+    """Per-candidate family-selection rows, across every margin that selected.
+
+    Margins that were given rather than selected contribute nothing, so an
+    all-fixed or all-KDE distribution reports an empty list.
+
+    Returns
+    -------
+    list of dict
+        One row per candidate considered, in variable order. Each carries the
+        variable, the family, its parameter count, the criteria, whether it was
+        selected, and — for a candidate that was not fitted — why.
+    """
+    return [
+      dict(row)
+      for margin in self._margins
+      for row in getattr(margin, "report_", ())
+    ]
 
   @property
   def dim(self) -> int:
@@ -542,9 +591,21 @@ class Vinedist(Generic[ArrayT]):
       raise ValueError(f"x must be two-dimensional; got {data.ndim} dimensions")
     d = data.shape[1]
 
+    if names is None:
+      # A DataFrame carries its own names, and `margins` is often keyed by them.
+      # Duck-typed: pandas is an extra, not a dependency of `core`.
+      columns = getattr(x, "columns", None)
+      if columns is not None:
+        names = [str(c) for c in columns]
+
     specs = resolve_margins(margins, d, names=names)
     fitted = [
-      fit_margin(specs[j], data[:, j], weights=weights) for j in range(d)
+      fit_margin(
+        _named(specs[j], names[j] if names is not None else None),
+        data[:, j],
+        weights=weights,
+      )
+      for j in range(d)
     ]
 
     # A copula needs its var_types up front, so both come from the fitted

--- a/tests/test_core_vinedist.py
+++ b/tests/test_core_vinedist.py
@@ -17,7 +17,11 @@ import numpy as np
 import pytest
 
 import pyvinecopulib as pv
-from pyvinecopulib.margins import EmpiricalMargin, Kde1dMargin
+from pyvinecopulib.margins import (
+  EmpiricalMargin,
+  Kde1dMargin,
+  MarginSelector,
+)
 
 stats = pytest.importorskip("scipy.stats")
 
@@ -349,3 +353,42 @@ def test_repr_names_the_margin_families(continuous: np.ndarray) -> None:
   """`repr` shows the dimension and what each margin is."""
   dist = pv.Vinedist.from_data(continuous, margins="kde")
   assert repr(dist) == "Vinedist(dim=2, margins=[kde1d, kde1d])"
+
+
+# --- selection reporting ---------------------------------------------------- #
+
+
+def test_from_data_reads_dataframe_column_names(data: np.ndarray) -> None:
+  """A mapping keyed by column name works on a DataFrame without `names=`."""
+  pd = pytest.importorskip("pandas")
+  df = pd.DataFrame(data, columns=["real", "positive", "count"])
+  dist = pv.Vinedist.from_data(df, margins={"real": Kde1dMargin()})
+  assert dist.dim == 3
+
+
+def test_selection_report_names_each_variable(data: np.ndarray) -> None:
+  """Report rows identify their variable, so a multi-column table is readable."""
+  dist = pv.Vinedist.from_data(
+    data[:, :2], margins="parametric", names=["real", "positive"]
+  )
+  report = dist.selection_report()
+  assert report
+  assert {row["column"] for row in report} == {"real", "positive"}
+  selected = {row["column"] for row in report if row["selected"]}
+  assert selected == {"real", "positive"}
+
+
+def test_selection_report_is_empty_without_a_selector(data: np.ndarray) -> None:
+  """Margins that were given rather than selected contribute no rows."""
+  assert pv.Vinedist.from_data(data).selection_report() == []
+
+
+def test_from_data_leaves_the_caller_s_specification_alone(
+  data: np.ndarray,
+) -> None:
+  """Naming a selector must not mutate an object the caller still holds."""
+  selector = MarginSelector(candidates=["norm", "logistic"])
+  dist = pv.Vinedist.from_data(data[:, :1], margins=[selector], names=["real"])
+  assert selector.name is None
+  assert list(selector.report_) == []
+  assert dist.selection_report()[0]["column"] == "real"


### PR DESCRIPTION
Stacked on #287. Three gaps in the family-selection surface, all found by writing the example notebook against the real API rather than against the design.

## 1. A DataFrame's column names were never read

The mapping-keyed form the design sketched did not work:

```python
>>> pv.Vinedist.from_data(df, margins={"income": MarginSelector()})
ValueError: margins mapping names 'income', which is not a variable
```

`names` was only ever what the caller passed explicitly, so on a DataFrame it was `None` and every mapping key looked unknown. The error message was actively misleading too — `income` *is* a variable; it just had no name the resolver could see.

`from_data` now takes `names` from a `columns` attribute when the caller supplies none. Duck-typed on purpose: pandas is in the `[sklearn]` extra, and `pyvinecopulib.core` must keep importing without it (asserted by an existing subprocess test).

## 2. Report rows did not say which variable they belonged to

`MarginSelector` writes `"column": self.name` on every row, and `name` defaults to `None`. Nothing supplied it, so `margins="parametric"` on a 3-column frame produced a table where all rows read `column=None` — unreadable the moment there is more than one variable.

`sklearn/_base.py:403-404` already did exactly this for its own estimators; `from_data` was simply missing the equivalent. It now labels a selector with its variable, with one deliberate difference from a naive port:

```python
if getattr(spec, "name", "") is not None:
    return spec          # a caller-set name wins
spec = copy.deepcopy(spec)
spec.name = name         # copy before mutating
```

`resolve_margins` only deep-copies on the broadcast path, so a sequence or mapping hands through the caller's own objects. Setting `.name` on those would mutate an argument the caller still holds. Copying only in the narrow case (a selector with no name) avoids that without changing identity for everything else — a pre-fitted margin passed in is still the same object on `dist.margins`.

## 3. `Vinedist.selection_report()` did not exist

The design listed it; only the sklearn estimators had `selection_report_`. So the sole access from a plain `Vinedist` was per-margin `report_`, which callers had to flatten themselves — which is what the notebook does. Margins that were given rather than selected contribute nothing, so an all-fixed or all-KDE distribution reports `[]` rather than raising or inventing rows.

I left `sklearn`'s `selection_report_` as it is: it is assembled during marginal fitting, before the `Vinedist` exists, and for `VineRegressor` it orders the response last where the joint model puts it first. Rewiring it would change row order in an unreleased API for no gain.

## Verification

CPU-pinned, targeted files only — no whole-suite run.

```
uv run --no-sync pytest tests/test_core_vinedist.py tests/test_sklearn_margins.py \
                        tests/test_margins.py -q          # 80 passed
make check                                                # ruff, format, bandit, codespell, ty all pass
rm -rf docs/_generate docs/_build && make docs             # build succeeded (nitpicky, -W)
```

Four tests added:

| test | what it pins |
|---|---|
| `test_from_data_reads_dataframe_column_names` | the case in §1, guarded with `importorskip("pandas")` since the wheel-test env has none |
| `test_selection_report_names_each_variable` | every row carries its variable, and each variable has a winner |
| `test_selection_report_is_empty_without_a_selector` | no rows invented for given margins |
| `test_from_data_leaves_the_caller_s_specification_alone` | the caller's selector keeps `name is None` and an empty `report_`, while the fitted copy is labeled |

Measured behavior on gamma + normal columns, as a sanity check that the labels are right rather than merely present:

```
selection_report rows : 17 | columns: ['a', 'b']
selected              : [('a', 'gamma'), ('b', 'norm')]
```

`concepts.rst` gains one sentence pointing at the new method next to where the per-candidate table is discussed.
