### PR TITLE
docs: correct three claims in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -339,11 +339,17 @@ safeguard that makes a whole-suite run acceptable.** The rules:
 
 1. **An agent does not run the suite.** No `make test`, no
    `pytest tests/` — not CPU-pinned, and not "just for the test count".
-   Push the branch and let CI run it: `.github/workflows/pypi.yml`
-   covers 15 build-and-test legs with `--extra sklearn --extra torch`
-   plus the wheel-install legs, which is broader coverage than any
-   local run, and `gh pr checks` / `gh run view --job <id> --log-failed`
-   reads the result.
+   Push the branch and let CI run it, and know which leg runs what:
+   the 15 `build` legs run `pytest tests/` under cibuildwheel with only
+   `pytest-cov` and `pytest-rerunfailures` installed, so every test
+   guarded by `importorskip` **skips** there; the 15
+   `install_and_unit_test` legs sync `--extra examples --extra sklearn
+   --extra torch`, install the wheel, and run both `pytest tests/` and
+   the notebooks. That second matrix is the one that covers the optional
+   extras, and between them the coverage is broader than any local run.
+   `gh pr checks` / `gh run view --job <id> --log-failed` reads the
+   result — though a run triggered by `gh workflow run` attaches its
+   checks to the commit without `gh pr checks` listing them.
 2. **Targeted single files are fine**, CPU-pinned:
    `CUDA_VISIBLE_DEVICES="" uv run --no-sync pytest
    tests/test_<topic>.py --no-cov`. To check that a test survives
@@ -651,8 +657,9 @@ automatically.
   a left-limit block by hand. `logpdf` sums logs rather than
   accumulating a product, because the marginal term carries the scale
   and a `d = 50` product underflows. `simulate` is
-  `marginal_icdf(copula.inverse_rosenblatt(w))` and never calls a
-  margin's own sampler, which is why `simulate` stays off the protocol.
+  `marginal_icdf(copula.simulate(n, ...))`, so it inherits the copula's
+  quasi-random and seeding options and never calls a margin's own
+  sampler — which is why `simulate` stays off the protocol.
 
 ### `pyvinecopulib.margins`
 
@@ -660,7 +667,10 @@ The univariate half of `Vinedist`, kept out of `core` so that `core`
 imports without SciPy. Three groups:
 
 - **Built-in margins** — `Kde1dMargin` (the default; wraps `Kde1d`, and
-  passes `xmin` for count data so no mass lands on negative counts),
+  takes `xmin` / `xmax` so a bounded variable is not fitted past its
+  support — the sklearn estimators fill those in from a categorical's
+  declared levels, since otherwise the density grid is padded past the
+  data),
   `EmpiricalMargin` (the `to_pseudo_obs` rank transform as a margin, so
   *"`Vinecop` on `to_pseudo_obs(x)`"* is literally *"`Vinedist` with
   empirical margins"*), `ParametricMargin` (one SciPy family) and


### PR DESCRIPTION
Stacked on #290. Documentation only. Three claims I wrote earlier in this stack that are wrong on the specifics — none of them changes the conclusion it was supporting, but a normative file has to be right about the details or it misleads the next reader.

## 1. `Vinedist.simulate` does not go through `inverse_rosenblatt`

The design sketched `marginal_icdf(copula.inverse_rosenblatt(w))` and I repeated it without reading the implementation, which is:

```python
return self.marginal_icdf(self._copula.simulate(n, **kwargs))
```

The point stands — no margin's own sampler is ever called, which is why `simulate` is not a protocol member — and delegating to the copula's `simulate` is the better shape, since it inherits `qrng` and seeding rather than reimplementing them.

## 2. `Kde1dMargin` does not infer bounds for counts

It takes `xmin` / `xmax` and forwards them to `Kde1d`. What supplies them is the sklearn layer, from a categorical's declared levels (#290). The old wording credited the margin with inference it does not do — and would have sent a reader looking for the logic in the wrong file.

This is also why the correction lands here rather than as an amendment to #285: the behavior it describes does not exist until #290, so a doc at that commit could not truthfully state it.

## 3. The CI note named the wrong job

It said the suite runs on *"15 build-and-test legs with `--extra sklearn --extra torch`"*. It does not. Those legs run `pytest {project}/tests` under cibuildwheel with `test-requires = ["pytest-cov", "pytest-rerunfailures"]` — no scipy, sklearn, torch or pandas — so every `importorskip`-guarded test **skips** there.

That is not academic: it is precisely why a `scipy.special` import reached from `tests/conftest.py` failed on that matrix and nowhere else, which was #280's only failure.

The extras are on the 15 `install_and_unit_test` legs ([pypi.yml:362](.github/workflows/pypi.yml#L362)), which sync `--extra examples --extra sklearn --extra torch`, install the wheel, and run `pytest tests/` plus `pytest --nbmake examples/`. Since the whole purpose of that note is to tell an agent to trust CI rather than run the suite locally, it has to name the leg that actually covers the code.

It now also records that a run triggered by `gh workflow run` attaches its checks to the **commit** without `gh pr checks` listing them — worked out the hard way twice in this stack, after pushing a stacked branch alongside its base left four PRs at `mergeable=UNKNOWN` with no workflow run created at all.

## Verification

`codespell AGENTS.md` clean; pre-commit whitespace / EOF hooks pass. Nothing reads this file at build time.

Claims I re-checked while I was in there, and which are correct as written: `pdf` / `cdf` really are enforced abstract on `MarginBase` (via the `Protocol` base plus `ABC` — `Can't instantiate abstract class … without an implementation for abstract method 'pdf'`), a `pdf`+`cdf`-only subclass really does get a working inherited `icdf`, the inherited `fit` really does raise, `solve_increasing` really does back `MarginBase.icdf` ([margin_base.py:209](src/pyvinecopulib/core/margin_base.py#L209)), `copula_data` really does clamp once and raise on `cdf_left > cdf`, `logpdf` really does sum logs, and `MarginSelector` really does fall back to `Kde1dMargin` with a single warning.