### PR TITLE
refactor(sklearn)!: delegate the marginal half to Vinedist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@
 - Rename the sampling entry points to `sample`: `simulate` on `Bicop` / `Vinecop` / `RVineStructure` / `Kde1d` and `utils.simulate_uniform` stay as `DeprecationWarning` aliases, while the unreleased `simulate_conditional` → `sample_conditional` and `_simulate_uniform` → `_sample_uniform` hook get none (#297).
 - Add `n_jobs` to `VineDensity` and `VineRegressor`, following the scikit-learn convention (`None` is one thread, `-1` every processor). It governs fitting and every evaluation, where the fit-time `num_threads` used to pin both: `VineRegressor.predict` on 2000 rows goes from 1.13 s to 0.26 s, and a 20-dimensional fit from 9.4 s to 1.8 s. The default stays serial, since a caller parallelizing over vines owns the parallelism. Results are bit-identical at any thread count (#297).
 - Collapse the three hand-rolled Graphviz retry loops into one composite action on `nick-fields/retry`, with a per-manager retry shape: apt and brew fail slowly so they get few attempts and a long budget, Chocolatey fails fast so it gets more attempts and a short one, and each apt attempt is bounded from the inside by `sudo timeout` (#297).
+- `VineDensity` and `VineRegressor` take a `margins=` keyword and delegate the whole marginal half to `Vinedist`, so the Sklar assembly has one implementation instead of two. `margins=None` still fits a `Kde1d` per column and reproduces the previous numbers (#293).
+- The sklearn estimators' internal `_x_kde1d` / `_y_kde1d` attributes are gone -- the fitted margins are `distribution_.margins` -- and `margins` sits between `backend` and `batch_size`, so a positional call past `backend` shifts (#293).
+- `VineDensity` refuses a margin with no density at fit time rather than at the first `score_samples`. `VineRegressor` accepts one: its quadrature reads the copula density and the response margin's `icdf` only (#293).
+- `VineRegressor` requires a continuous response margin (#293).
+- `VineRegressor` takes its `use_grid=True` quadrature on the probability scale: substituting `p = F_Y(y)` in the conditional expectation cancels the marginal density, so the nodes are `icdf` of a fixed grid of `n_nodes` probability levels and the weights are the copula density alone (#293).
+- Any continuous margin can now be `VineRegressor`'s response, where before the nodes and an extra density factor were read off the response margin's `Kde1d` interpolation grid; `n_nodes=401` replaces the implicit dependence on that grid's size (#293).
+- `VineRegressor` predictions shift by around 1e-5 response standard deviations for an unbounded response margin, and by far more for a bounded one, whose grid is not uniform in `y` -- the spacing the old weights omitted (#293).
+- `VineRegressor` refuses a conditional response margin: the quadrature inverts one shared probability grid, which a margin whose quantiles move with the covariates turns into one grid per test row (#293).
 
 ### New features in `pyvinecopulib`
 
@@ -91,6 +99,8 @@
 - Add `RVineStructure.get_min_array()`, `get_needed_hfunc1()` and `get_needed_hfunc2()`, returning the whole `[tree][edge]` triangular array that the existing per-entry accessors index into (#251).
 - `Vinecop.pair_copulas` is now settable, so pair copulas can be replaced as a group on a fitted vine; the assignment validates the nested shape against the structure (#251).
 
+- The sklearn estimators publish the fitted model as `distribution_`, a `Vinedist` that evaluates through the fitted backend, and the family-selection table of any selecting margin as `selection_report_` (#293).
+- `distribution_.sample` goes through the backend that fitted the vine, as its other methods do; the wrapper had kept the pre-rename name, so the call fell through to the raw vine and skipped the backend's conversion of the result (#293).
 - Add `Vinedist.copula_data` and `Vinedist.copula_var_types`: from a set of margins, the copula-scale layout for some data and the `var_types` a copula must be fitted with. That is what "fit your own copula, then wrap it" needs, and what the sklearn estimators use (#292).
 - `resolve_margins` takes `default=`, one specification per variable, so a caller that knows something per variable keeps it for the variables a mapping does not address (#292).
 - Add `Vinedist.selection_report`, the per-candidate family-selection rows across every margin that selected, labeled by variable. `from_data` reads a DataFrame's column names, so `margins=` may be a mapping keyed by name (#292).
@@ -117,7 +127,10 @@
 - Reject non-finite `X` / `y` in the `pyvinecopulib.sklearn` estimators instead of passing them to `Kde1d`, which reads NaN as a segmentation fault (#263).
 - Port the `integrate_2d` marginal-renormalization fix to the torch backend (`InterpolationGrid2D.integrate_2d` and `integrate_2d_batched`) so `TorchBicop.cdf` enforces ``C(1, u_2) = u_2`` exactly, matching the post-vinecopulib#667 C++ CDF to machine precision on the on-the-fly path ([vinecopulib#667](https://github.com/vinecopulib/vinecopulib/pull/667)).
 - Declare `BicopFamily` enum members as class attributes in the generated type stubs so the documented `pv.BicopFamily.clayton` access pattern passes static type checking (`ty` / pyright / mypy), not only the module-level constants (#223).
+- Fit the `{0, 1}` dummies of an expanded unordered categorical on `[0, 1]` in the sklearn estimators. Their bounds are known exactly, but were never passed, so the kernel-density grid was padded past the data and put mass on values that cannot occur (#293).
+- Pass the declared support of an ordered categorical to its marginal fit in the sklearn estimators. Only the expanded `{0, 1}` dummies were bounded, so a count column's kernel-density grid was still padded below its smallest level (#293).
 - `Vinedist.cdf` hands the copula the full `(n, d + k)` layout. A distribution function needs only the marginal `F` values and the copula reads only those, but it validates the whole layout, so a margin with atoms made `cdf` raise (#292).
+- Reject complex `X` / `y` in the sklearn estimators rather than casting each column to float and dropping the imaginary part in silence (#293).
 - Pin the RNG of the discrete `ParametricMargin` fitter. `scipy.stats.fit` optimizes with an unseeded `differential_evolution`, so the same counts gave a different parameter vector -- and a different `MarginSelector.report_` -- on every call (#292).
 
 ### Dependency changes

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -719,22 +719,31 @@ with :math:`\psi_\beta(y) = y - \beta` recovering the
 conditional mean :math:`\beta(\mathbf x) = \mathbb E[Y \mid \mathbf X = \mathbf x]`
 and :math:`\psi_\beta(y) = \mathbb 1\{y < \beta(\mathbf x)\} - \tau`
 recovering the conditional :math:`\tau`-quantile. In practice the
-integral is replaced by a weighted sum over a grid
-:math:`\{y_1, \ldots, y_G\}`:
+integral is taken on the probability scale, substituting
+:math:`p = \hat F_Y(y)`, and replaced by a weighted sum over a
+fixed grid of levels :math:`\{p_1, \ldots, p_G\} \subset (0, 1)`:
 
 .. math::
 
-   \sum_{g = 1}^G \psi_\beta(y_g) \,
-   \hat f_Y(y_g) \,
+   \sum_{g = 1}^G
+   \psi_\beta\!\bigl(\hat F_Y^{-1}(p_g)\bigr) \,
    \hat c_{\mathcal V, \mathcal D}\!\bigl(
-   \hat F_Y(\mathbf x), \, \hat F_Y(y_g)
-   \bigr)
+   p_g, \, \hat F_{\mathbf X}(\mathbf x)
+   \bigr) \, \Delta_g
    \;\approx\; 0,
 
-which :class:`pyvinecopulib.sklearn.VineRegressor` solves
+with :math:`\Delta_g` the spacing of the nodes. The substitution
+cancels the marginal density :math:`\hat f_Y` that the
+response-scale form of the same sum carries, so the rule asks the
+response margin for nothing but its inverse CDF and places every
+node inside its support by construction.
+
+:class:`pyvinecopulib.sklearn.VineRegressor` solves this
 numerically. Pass the quantile levels you want via the
 ``quantiles=`` constructor argument; the predicted conditional
-mean is always returned when ``mean=True``. Batching over test
+mean is always returned when ``mean=True``. The node count is
+``n_nodes=``, and ``use_grid=False`` swaps the quadrature for the
+exact weighted sum over the training responses. Batching over test
 rows is controlled by ``batch_size=``.
 
 

--- a/src/pyvinecopulib/sklearn/__init__.py
+++ b/src/pyvinecopulib/sklearn/__init__.py
@@ -4,10 +4,9 @@ This subpackage wraps the core pyvinecopulib machinery behind the
 standard sklearn ``BaseEstimator`` / ``fit`` / ``predict`` interface.
 Two estimators ship:
 
-- :class:`VineDensity` — non-parametric joint-density estimator. Fits
-  univariate marginals with :class:`pyvinecopulib.core.Kde1d`, then a
-  vine copula on the resulting pseudo-observations. Exposes
-  ``score_samples`` / ``pdf`` / ``cdf`` / ``sample``.
+- :class:`VineDensity` — joint-density estimator. Fits univariate
+  margins, then a vine copula on the resulting pseudo-observations.
+  Exposes ``score_samples`` / ``pdf`` / ``cdf`` / ``sample``.
 - :class:`VineRegressor` — non-parametric conditional mean / quantile
   regressor built from a vine copula over ``(Y, X)``. Predictions are
   weighted statistics of the training responses.
@@ -22,6 +21,15 @@ Requires scikit-learn and pandas. Install with
 
 Notes
 -----
+**Margins.** The marginal half of the model is configured with
+``margins=``, in any form :func:`pyvinecopulib.margins.resolve_margins`
+accepts: an alias (``"kde"``, the default, ``"empirical"``,
+``"parametric"``), one margin broadcast to every column, a per-column
+sequence, a mapping keyed by feature name, or a callable. Fitting
+assembles both halves into a :class:`pyvinecopulib.core.Vinedist`,
+published as ``distribution_``; ``selection_report_`` carries the
+per-candidate table of any margin that chose its own family.
+
 **Backends.** By default the estimators run on ``Vinecop`` (the
 default backend), so the sklearn module
 **does not require PyTorch**. Pass a configured

--- a/src/pyvinecopulib/sklearn/_base.py
+++ b/src/pyvinecopulib/sklearn/_base.py
@@ -1,6 +1,8 @@
+import copy
 import os
 import warnings
 from numbers import Integral
+from typing import Any, Optional
 
 import numpy as np
 import pandas as pd
@@ -13,29 +15,42 @@ from sklearn.utils.validation import (
   check_random_state,
 )
 
-
+from ..core import Vinedist
 from ..core import Kde1d
-from .backends import resolve_backend
+from ..margins import resolve_margins
+from ..margins._resolve import fit_margin
+from .backends import _BackendVinecop, resolve_backend
 
 # Shared docstring fragments interpolated into VineDensity / VineRegressor
 # class docstrings via f-strings. Defined once here, used by both subclasses
 # so changes propagate without copy-paste.
 
 _DOC_PIPELINE = r"""The estimator follows the standard pyvinecopulib
-two-step pipeline: a univariate kernel density estimator
-(``Kde1d``) is fit to each column, the marginal CDFs transform the data
-to pseudo-observations
+two-step pipeline: a univariate margin is fit to each column, the
+marginal CDFs transform the data to pseudo-observations
 :math:`U_j = \hat F_j(X_j) \in [0, 1]`, and a vine copula is fit on
-the pseudo-observations. For discrete columns the left limit
+the pseudo-observations. For columns with atoms the left limit
 :math:`\hat F_j(X_j^-)` is also stacked so the vine sees a continuous
 proxy. Unordered categoricals are first expanded to ordered
 ``{0, 1}`` dummies via `expand_factors`.
 
-Fit-time configuration is bundled in a backend object passed via
-``backend=``. The default ``VinecopBackend`` wraps ``Vinecop`` and has
-no extra dependencies; ``TorchVinecopBackend`` routes the same
-pipeline through the PyTorch evaluator (GPU / autograd). See the
-:doc:`concepts page </concepts>` for the underlying vine-copula
+The two halves are configured separately and symmetrically. Margins
+come from ``margins=``, which defaults to a boundary-corrected kernel
+density (``Kde1d``) per column and accepts anything
+:func:`pyvinecopulib.margins.resolve_margins` understands --- an alias
+such as ``"empirical"`` or ``"parametric"``, one margin broadcast to
+every column, a per-column sequence, or a mapping keyed by feature
+name. The copula comes from ``backend=``: the default
+``VinecopBackend`` wraps ``Vinecop`` and has no extra dependencies,
+while ``TorchVinecopBackend`` routes the same pipeline through the
+PyTorch evaluator (GPU / autograd).
+
+Fitting assembles a ``Vinedist`` --- the copula and its margins as one
+object --- and every post-fit method evaluates through it. It is
+published as ``distribution_``, so the fitted joint distribution is
+usable outside the estimator; ``selection_report_`` carries the
+per-candidate table of any margin that selected its own family. See
+the :doc:`concepts page </concepts>` for the underlying vine-copula
 construction.
 """
 
@@ -55,7 +70,8 @@ vine structure (Bedford & Cooke, 2002; Aas et al., 2009). Passing
 """
 
 _DOC_DISCRETE = r"""Discrete (or expanded unordered-categorical)
-columns are handled via ``Kde1d``'s ``type="discrete"`` mode:
+columns are handled by the margin's own variable type --- for the
+default ``Kde1d`` that is ``type="discrete"``:
 pseudo-observations stack :math:`\hat F_j(X_j)` and
 :math:`\hat F_j(X_j^-)` so the vine evaluation sees the appropriate
 continuous proxy. Handled transparently by `fit` and `pdf`.
@@ -74,6 +90,31 @@ _DOC_REFERENCES = r"""References
        Journal of the American Statistical Association, 119(546),
        1168--1180.
 """
+
+
+def _categorical_bounds(dtype: Any) -> Optional[tuple[float, float]]:
+  """Exact support of an ordered categorical column, when it states one.
+
+  Parameters
+  ----------
+  dtype : numpy.dtype or pandas.api.extensions.ExtensionDtype
+      A column's dtype.
+
+  Returns
+  -------
+  tuple of float, or None
+      ``(min, max)`` over the declared categories, or ``None`` when the dtype is
+      not categorical or its categories are not numeric.
+  """
+  if not isinstance(dtype, pd.CategoricalDtype):
+    return None
+  try:
+    levels = np.asarray(dtype.categories, dtype=float)
+  except (TypeError, ValueError):
+    return None
+  if levels.size == 0:
+    return None
+  return (float(levels.min()), float(levels.max()))
 
 
 def expand_factors(df: pd.DataFrame) -> pd.DataFrame:
@@ -129,10 +170,11 @@ class VineBase(BaseEstimator):
   Base class for vine-copula based estimators.
 
   Provides common functionality for:
-  - Marginal distribution fitting (Kde1d)
+  - Marginal distribution fitting (via ``margins=``)
   - Data preprocessing and validation
   - Pseudo-observation transformation
   - Vine copula fitting (via a backend strategy object)
+  - Assembling both halves into a fitted ``Vinedist``
   - Batched operations
 
   Per the scikit-learn developer guide, ``__init__`` only stores
@@ -141,8 +183,20 @@ class VineBase(BaseEstimator):
   convention.
   """
 
+  # `schema_` is heterogeneous by design -- per-column variable types, and the
+  # bounds of the columns whose support the input pinned down. Declared here so
+  # the type checker knows that; `_validate_input(reset=True)` sets it, and
+  # `getattr(self, "schema_", None)` is still how a caller-set one is read.
+  schema_: dict[str, Any]
+
+  #: Whether this estimator reports a density on the original scale, and so
+  #: cannot accept a margin that has none. `VineRegressor` does not: its
+  #: quadrature reads the copula density and the response margin's `icdf` only.
+  _needs_marginal_density: bool = False
+
   _parameter_constraints: dict = {
     "backend": [object, None],
+    "margins": [object, None],
     "batch_size": [Interval(Integral, 1, None, closed="left")],
     "random_state": ["random_state"],
     "n_jobs": [Integral, None],
@@ -151,6 +205,7 @@ class VineBase(BaseEstimator):
   def __init__(
     self,
     backend=None,
+    margins=None,
     batch_size: int = 100,
     random_state=None,
     n_jobs=None,
@@ -165,6 +220,18 @@ class VineBase(BaseEstimator):
         ``FitControlsTorchVinecop`` for the torch backend) and an
         optional structure. `None` resolves to a default
         ``VinecopBackend`` at fit time.
+    margins : object, default=None
+        What to fit to each column, in any form
+        :func:`pyvinecopulib.margins.resolve_margins` accepts: an alias
+        (``"kde"``, ``"empirical"``, ``"parametric"``), one margin
+        broadcast to every column, a sequence of length
+        ``n_features_in_``, a mapping keyed by feature name or
+        position, or a callable taking a column and returning a
+        margin. `None` fits a ``Kde1d`` per column, carrying the
+        variable type inferred from the input and, for the ``{0, 1}``
+        dummies of an expanded unordered categorical, the bounds of its
+        support. Stored as-is and never mutated: every specification is
+        fitted on a copy.
     batch_size : int, default=100
         Number of test points to process per batch when making
         predictions. ``1`` minimizes memory at the cost of speed;
@@ -188,6 +255,7 @@ class VineBase(BaseEstimator):
         when one vine is the whole job.
     """
     self.backend = backend
+    self.margins = margins
     self.batch_size = batch_size
     self.random_state = random_state
     self.n_jobs = n_jobs
@@ -248,7 +316,23 @@ class VineBase(BaseEstimator):
           "discrete" if isinstance(dtype, pd.CategoricalDtype) else "continuous"
           for dtype in X_exp.dtypes
         ]
-        self.schema_ = {"kde1d_types": kde1d_types}
+        # Bounds are passed wherever the input states them, and left unset
+        # wherever they would be a guess. A categorical declares its levels, so
+        # its support is known rather than assumed: an expanded name absent from
+        # the input is a {0, 1} dummy, and any other categorical is bounded by
+        # its own categories. Without this the kernel-density grid is padded
+        # past the data and puts mass on values that cannot occur -- a count
+        # column picks up density below zero. A continuous column, or a discrete
+        # one declared through a pre-set `schema_`, has no stated support and
+        # keeps `None`.
+        original = set(X.columns)
+        bounds: list[Optional[tuple[float, float]]] = []
+        for name, dtype in zip(self._expanded_columns, X_exp.dtypes):
+          if name not in original:
+            bounds.append((0.0, 1.0))
+          else:
+            bounds.append(_categorical_bounds(dtype))
+        self.schema_ = {"kde1d_types": kde1d_types, "bounds": bounds}
         self.n_features_in_ = X_exp.shape[1]
         X_arr = X_exp.to_numpy()
       else:
@@ -270,8 +354,8 @@ class VineBase(BaseEstimator):
         # ``schema_`` set by the caller (or by a subclass) before
         # ``fit`` to declare per-column kde1d types, and otherwise
         # treat every column as continuous.
-        existing = getattr(self, "schema_", None)
-        if existing is not None and "kde1d_types" in existing:
+        existing = getattr(self, "schema_", None) or {}
+        if "kde1d_types" in existing:
           kde1d_types = existing["kde1d_types"]
           if len(kde1d_types) != X.shape[1]:
             raise ValueError(
@@ -280,7 +364,12 @@ class VineBase(BaseEstimator):
             )
         else:
           kde1d_types = ["continuous"] * X.shape[1]
-        self.schema_ = {"kde1d_types": kde1d_types}
+        bounds = existing.get("bounds") or [None] * X.shape[1]
+        if len(bounds) != X.shape[1]:
+          raise ValueError(
+            "schema_['bounds'] length does not match number of features in X."
+          )
+        self.schema_ = {"kde1d_types": kde1d_types, "bounds": bounds}
         self.n_features_in_ = X.shape[1]
       else:
         check_is_fitted(self, attributes=["n_features_in_"])
@@ -288,6 +377,10 @@ class VineBase(BaseEstimator):
           raise ValueError("X has wrong number of features.")
       X_arr = X
 
+    # Margins are fitted on float columns, so a complex input would otherwise
+    # be cast and lose its imaginary part without saying so.
+    if np.iscomplexobj(X_arr) or (y is not None and np.iscomplexobj(y)):
+      raise ValueError("Complex data not supported")
     # The marginal estimator is C++ and reads NaN / inf as a segmentation
     # fault rather than an error, so nothing downstream can report this.
     assert_all_finite(X_arr, input_name="X")
@@ -296,11 +389,132 @@ class VineBase(BaseEstimator):
       return X_arr, y
     return X_arr
 
+  def _column_name(self, j: int) -> str:
+    """Name of expanded column ``j``, for reports and messages.
+
+    Parameters
+    ----------
+    j : int
+        Column index.
+
+    Returns
+    -------
+    str
+        The feature name for DataFrame input, else a positional stand-in.
+    """
+    names = getattr(self, "_expanded_columns", None)
+    if names is not None and j < len(names):
+      return str(names[j])
+    return f"x{j}"
+
+  def _default_margin_specs(self) -> list[Kde1d]:
+    """One unfitted kernel-density margin per column, from the schema.
+
+    This is what ``margins=None`` means, and what a column a ``margins=``
+    mapping does not address falls back to.
+
+    Returns
+    -------
+    list of Kde1d
+        One margin per feature, carrying the variable type and whatever bounds
+        the input told us about.
+    """
+    types = self.schema_["kde1d_types"]
+    bounds = self.schema_.get("bounds") or [None] * len(types)
+    specs = []
+    for type_, bound in zip(types, bounds):
+      lo, hi = (
+        (None, None) if bound is None else (float(bound[0]), float(bound[1]))
+      )
+      specs.append(Kde1d(type=type_, xmin=lo, xmax=hi))
+    return specs
+
+  def _fit_one_margin(self, spec: Any, column: np.ndarray, name: str) -> Any:
+    """Fit one column's margin.
+
+    Parameters
+    ----------
+    spec : object
+        A specification from :func:`pyvinecopulib.margins.resolve_margins`.
+    column : ndarray, shape (n_samples,), dtype float
+        The column to fit.
+    name : str
+        The variable's name, for a selector's report.
+
+    Returns
+    -------
+    MarginLike
+        The fitted margin.
+    """
+    # Fitting a margin mutates it, and `self.margins` is a constructor argument
+    # that has to survive `fit` untouched so `clone` reproduces the estimator;
+    # hence every specification is fitted on a copy of itself.
+    spec = copy.deepcopy(spec)
+    # A selector records which variable each candidate was fitted to; supply
+    # the name when the caller has not.
+    if hasattr(spec, "report_") and getattr(spec, "name", "") is None:
+      spec.name = name
+    margin = fit_margin(spec, np.asarray(column, dtype=float))
+    if self._needs_marginal_density:
+      self._require_density(margin, name, column)
+    return margin
+
+  def _require_density(
+    self, margin: Any, name: str, column: np.ndarray
+  ) -> None:
+    """Refuse a margin with no density, at fit time rather than at first score.
+
+    A margin whose ``pdf`` is undefined -- an empirical distribution above all,
+    whose mass is not a density -- cannot serve an estimator that reports one.
+    Probed rather than declared, so a margin from anywhere is caught.
+
+    Parameters
+    ----------
+    margin : MarginLike
+        The fitted margin.
+    name : str
+        The variable's name, for the message.
+    column : ndarray, shape (n_samples,), dtype float
+        The data it was fitted to, to probe at.
+
+    Raises
+    ------
+    ValueError
+        If the margin has no density.
+    """
+    probe = np.asarray(column, dtype=float)[:1]
+    density: Any = getattr(margin, "logpdf", None) or margin.pdf
+    try:
+      density(probe)
+    except NotImplementedError as exc:
+      raise ValueError(
+        f"{type(self).__name__} needs a density on the original scale, but the "
+        f"margin for {name!r} ({type(margin).__name__}) has none: {exc}"
+      ) from exc
+
+  def _response_margin_spec(self) -> Any:
+    """The specification for the response margin.
+
+    ``margins`` addresses the features, so a per-variable form -- a sequence, or
+    a mapping over the feature names -- says nothing about the response, which
+    keeps the default. Anything that broadcasts (an alias, one margin, a
+    callable) applies to the response too, so ``margins="parametric"`` means
+    what it looks like.
+
+    Returns
+    -------
+    object
+        One specification, not yet fitted.
+    """
+    if isinstance(self.margins, (list, tuple, dict)):
+      return Kde1d()
+    return resolve_margins(self.margins, 1)[0]
+
   def _fit_marginals(
     self, X: np.ndarray, y: np.ndarray | None = None
   ) -> np.ndarray | tuple[np.ndarray, np.ndarray]:
     """
-    Fit marginal distributions (Kde1d) for features and optionally target.
+    Fit one margin per feature column, and the response's when given.
 
     Parameters
     ----------
@@ -316,21 +530,59 @@ class VineBase(BaseEstimator):
     y : ndarray or None
         Target values (unchanged) if provided, None otherwise.
     """
-    self._x_kde1d = []
-    assert (
-      self.schema_ is not None
-    )  # Guaranteed after _validate_input(reset=True)
-    for j in range(self.n_features_in_):
-      kde = Kde1d(type=self.schema_["kde1d_types"][j])
-      kde.fit(X[:, j])
-      self._x_kde1d.append(kde)
+    specs = resolve_margins(
+      self.margins,
+      self.n_features_in_,
+      names=getattr(self, "_expanded_columns", None),
+      default=self._default_margin_specs(),
+    )
+    self._x_margins = tuple(
+      self._fit_one_margin(specs[j], X[:, j], self._column_name(j))
+      for j in range(self.n_features_in_)
+    )
+    fitted = list(self._x_margins)
 
     if y is not None:
-      self._y_kde1d = Kde1d()
-      self._y_kde1d.fit(y)
+      self._y_margin = self._fit_one_margin(
+        self._response_margin_spec(), np.asarray(y, dtype=float), "y"
+      )
+      # The joint model orders the response first and gives it no left-limit
+      # column, which the prediction paths rely on.
+      if Vinedist.copula_var_types([self._y_margin])[0] != "c":
+        raise ValueError(
+          "The response margin must be continuous, but "
+          f"{type(self._y_margin).__name__} declares "
+          f"var_type={getattr(self._y_margin, 'var_type', 'c')!r}."
+        )
+      fitted.append(self._y_margin)
+
+    self.selection_report_ = [
+      dict(row) for margin in fitted for row in getattr(margin, "report_", ())
+    ]
+    if y is not None:
       return X, y
-    else:
-      return X
+    return X
+
+  def _bind_distribution(self, margins: Any) -> None:
+    """Publish the fitted vine and its margins as one ``Vinedist``.
+
+    The copula is wrapped so that it evaluates through the backend, which is
+    what keeps ``distribution_`` numerically identical to the estimator's own
+    methods -- including on the torch backend, where the raw vine returns
+    tensors on its own device.
+
+    Parameters
+    ----------
+    margins : sequence of MarginLike
+        The fitted margins, in the vine's variable order.
+
+    Returns
+    -------
+    None
+    """
+    self.distribution_ = Vinedist(
+      _BackendVinecop(self.backend_, self._vine), list(margins)
+    )
 
   def _resolve_runtime_state(self) -> None:
     """Resolve the random-state and backend at fit time. Sets
@@ -353,14 +605,17 @@ class VineBase(BaseEstimator):
     """
     Compute marginal pseudo-observations for new data, handling discrete vars.
 
+    A thin delegation to ``Vinedist.copula_data``, which owns the layout: one
+    column per variable, then one left-limit column per variable with atoms.
+
     Parameters
     ----------
     Z : array-like
         If is_y=False: shape (n_samples, d).
         If is_y=True : shape (n_samples,).
     is_y : bool, default=False
-        If True, transform response with y_kde1d.
-        If False, transform covariates with x_kde1d list.
+        If True, transform the response with its own margin.
+        If False, transform the covariates with theirs.
 
     Returns
     -------
@@ -368,38 +623,18 @@ class VineBase(BaseEstimator):
         If is_y=False: shape (n_samples, d [+ optional discrete sub-columns]).
         If is_y=True : shape (n_samples, 1).
     """
-    check_is_fitted(self, attributes=["_x_kde1d"])
-    if is_y and not hasattr(self, "_y_kde1d"):
+    check_is_fitted(self, attributes=["_x_margins"])
+    if is_y and not hasattr(self, "_y_margin"):
       raise RuntimeError(
         "Target marginal not fitted (y was not provided during fit)."
       )
 
-    Z = np.asarray(Z)
-
+    Z = np.asarray(Z, dtype=float)
     if is_y:
-      # Response is always treated continuous -> plain PIT.
-      result = self._y_kde1d.cdf(Z.squeeze(), check_fitted=False)
-      return np.asarray(result).reshape(-1, 1)
-
-    n_samples, n_features = Z.shape
-    u_cols = []
-    u_sub_cols = []
-
-    for j in range(n_features):
-      kde = self._x_kde1d[j]
-      zj = Z[:, j]
-      u_cols.append(kde.cdf(zj, check_fitted=False))
-      if kde.type == "discrete":
-        # Sub-CDF F(x^-) for the discrete component.
-        u_sub_cols.append(kde.cdf(zj - 1, check_fitted=False))
-
-    eps = 1e-10
-    u_cols = [np.clip(u, eps, 1 - eps) for u in u_cols]
-    if u_sub_cols:
-      u_sub_cols = [np.clip(u, eps, 1 - eps) for u in u_sub_cols]
-      return np.column_stack([*u_cols, *u_sub_cols])
-    else:
-      return np.column_stack(u_cols)
+      return np.asarray(
+        Vinedist.copula_data([self._y_margin], Z.reshape(-1, 1))
+      )
+    return np.asarray(Vinedist.copula_data(self._x_margins, Z))
 
   def _fit_vine(
     self, U: np.ndarray, var_types: list[str] | None = None
@@ -419,10 +654,7 @@ class VineBase(BaseEstimator):
     self
     """
     if var_types is None:
-      assert (
-        self.schema_ is not None
-      )  # Guaranteed after _validate_input(reset=True)
-      var_types = [x[0] for x in self.schema_["kde1d_types"]]
+      var_types = Vinedist.copula_var_types(self._x_margins)
 
     backend = self.backend_
     self._vine = backend.fit_vine(U, var_types=var_types)
@@ -459,38 +691,23 @@ class VineBase(BaseEstimator):
     density : ndarray of shape (n_samples,)
         Density or log-density values.
     """
-    check_is_fitted(self, attributes=["_vine"])
+    check_is_fitted(self, attributes=["distribution_"])
 
     X = self._validate_input(X, reset=False)
     if y is not None:
-      y = np.asarray(y).reshape(-1, 1)
+      y = np.asarray(y, dtype=float).reshape(-1, 1)
       if X.shape[0] != y.shape[0]:
         raise ValueError("X and y must have the same number of samples.")
-      U = np.column_stack([self._to_u_scale(y, is_y=True), self._to_u_scale(X)])
+      # The joint model orders the response first.
+      Z = np.column_stack([y, X])
     else:
-      U = self._to_u_scale(X)
+      Z = np.asarray(X, dtype=float)
 
-    pdf_vals = np.asarray(self.backend_.pdf(self._vine, U))
-    log_c = np.asarray(np.log(pdf_vals))
-
+    dist = self.distribution_
     if copula_only:
-      return np.asarray(log_c if log else np.exp(log_c))
+      u = Vinedist.copula_data(dist.margins, Z)
+      out = np.log(np.asarray(dist.copula.pdf(u)))
+    else:
+      out = np.asarray(dist.logpdf(Z))
 
-    # Marginal densities; clamp >0 to avoid log(0).
-    eps = 1e-10
-    f_x = np.array(
-      [
-        np.clip(self._x_kde1d[j].pdf(X[:, j]), eps, None)
-        for j in range(self.n_features_in_)
-      ]
-    )
-    log_f_x = np.sum(
-      np.log(f_x),
-      axis=0,
-    )
-    log_density = log_c + log_f_x
-    if y is not None:
-      log_f_y = np.log(self._y_kde1d.pdf(y.squeeze()))
-      log_density += log_f_y
-
-    return np.asarray(log_density if log else np.exp(log_density))
+    return np.asarray(out if log else np.exp(out))

--- a/src/pyvinecopulib/sklearn/backends.py
+++ b/src/pyvinecopulib/sklearn/backends.py
@@ -311,6 +311,107 @@ class TorchVinecopBackend(_VinecopBackendBase):
     return self
 
 
+class _BackendVinecop:
+  """A fitted vine that evaluates through the backend that fitted it.
+
+  The estimators hand this to :class:`~pyvinecopulib.core.Vinedist` in place of
+  the raw vine, so the distribution object evaluates exactly as the estimator
+  does — with the backend's threading / batching arguments, and with results
+  brought back to NumPy from wherever the vine computed them. Anything the
+  backend does not adapt is read off the vine itself, so this still answers
+  ``dim`` / ``var_types`` / ``structure`` and the Rosenblatt pair.
+
+  Parameters
+  ----------
+  backend : object
+      A resolved backend.
+  vine : object
+      The vine that backend fitted.
+  """
+
+  def __init__(self, backend: Any, vine: Any) -> None:
+    self.backend = backend
+    self.vine = vine
+
+  def __getattr__(self, name: str) -> Any:
+    # Underscored names are never forwarded: unpickling looks up `__setstate__`
+    # before `vine` exists, and forwarding it would recurse.
+    vine = self.__dict__.get("vine")
+    if vine is None or name.startswith("_"):
+      raise AttributeError(name)
+    return getattr(vine, name)
+
+  def pdf(self, u: np.ndarray) -> np.ndarray:
+    """Copula density at ``u``.
+
+    Parameters
+    ----------
+    u : ndarray, shape (n, d) or (n, d + k), dtype float
+        Copula-scale data.
+
+    Returns
+    -------
+    ndarray, shape (n,), dtype float
+        Density values.
+    """
+    return self.backend.pdf(self.vine, u)
+
+  def cdf(
+    self,
+    u: np.ndarray,
+    *,
+    N: int = 10000,
+    seeds: Optional[list[int]] = None,
+  ) -> np.ndarray:
+    """Copula distribution function at ``u``.
+
+    Parameters
+    ----------
+    u : ndarray, shape (n, d) or (n, d + k), dtype float
+        Copula-scale data.
+    N : int, optional
+        Number of quasi-random points for the Monte-Carlo integration.
+    seeds : list of int, or None, optional
+        RNG seeds.
+
+    Returns
+    -------
+    ndarray, shape (n,), dtype float
+        Distribution values.
+    """
+    return self.backend.cdf(self.vine, u, N=N, seeds=list(seeds or []))
+
+  def sample(self, n: int, *, seeds: Optional[list[int]] = None) -> np.ndarray:
+    """Draw ``n`` samples on the copula scale.
+
+    Parameters
+    ----------
+    n : int
+        Number of samples.
+    seeds : list of int, or None, optional
+        RNG seeds.
+
+    Returns
+    -------
+    ndarray, shape (n, d), dtype float
+        Samples in ``[0, 1]^d``.
+    """
+    return self.backend.sample(self.vine, n, seeds=list(seeds or []))
+
+  def __repr__(self) -> str:
+    """Name the backend and the vine it wraps.
+
+    Returns
+    -------
+    str
+        The representation.
+    """
+    return (
+      f"_BackendVinecop({type(self.backend).__name__}, "
+      f"{type(self.vine).__name__})"
+    )
+
+
 def resolve_backend(backend: Any) -> Any:
   """Coerce a user-supplied ``backend=`` value to a concrete backend.
 

--- a/src/pyvinecopulib/sklearn/density.py
+++ b/src/pyvinecopulib/sklearn/density.py
@@ -15,9 +15,14 @@ from ._base import (
 
 
 class VineDensity(DensityMixin, VineBase):
+  # `score_samples` reports a log-density on the original scale, so a margin
+  # without one is refused at fit time rather than at the first score.
+  _needs_marginal_density: bool = True
+
   def __init__(
     self,
     backend=None,
+    margins=None,
     batch_size: int = 100,
     random_state=None,
     n_jobs=None,
@@ -32,6 +37,11 @@ class VineDensity(DensityMixin, VineBase):
         ``VinecopBackend`` at fit time, which calls ``Vinecop.from_data()``
         with the nonparametric ``tll`` pair family. Pass
         ``TorchVinecopBackend`` for the PyTorch backend.
+    margins : object, default=None
+        The marginal half of the model, in any form
+        :func:`pyvinecopulib.margins.resolve_margins` accepts. `None`
+        fits a ``Kde1d`` per column with the variable type
+        inferred from the input.
     batch_size : int, default=100
         Number of test points processed per batch when evaluating
         the density. Higher values trade memory for throughput.
@@ -53,6 +63,7 @@ class VineDensity(DensityMixin, VineBase):
     """
     super().__init__(
       backend=backend,
+      margins=margins,
       batch_size=batch_size,
       random_state=random_state,
       n_jobs=n_jobs,
@@ -80,9 +91,8 @@ class VineDensity(DensityMixin, VineBase):
     X = self._validate_input(X, reset=True)
     self._resolve_runtime_state()
     self._fit_marginals(X)
-    U = self._to_u_scale(X)
-    var_types = [x[0] for x in self.schema_["kde1d_types"]]
-    self._fit_vine(U, var_types=var_types)
+    self._fit_vine(self._to_u_scale(X))
+    self._bind_distribution(self._x_margins)
     return self
 
   def score_samples(self, X: np.ndarray | pd.DataFrame) -> np.ndarray:
@@ -141,7 +151,7 @@ class VineDensity(DensityMixin, VineBase):
   def sample(self, n_samples: int = 1, random_state=None) -> np.ndarray:
     """Draws samples from the fitted joint density.
 
-    Samples :math:`U \\sim C` via ``Vinecop.sample()`` and pushes each
+    Samples :math:`U \\sim C` from the fitted copula and pushes each
     component back through the inverse marginal CDF :math:`F_j^{-1}`
     to obtain a sample in the original feature space.
 
@@ -156,9 +166,14 @@ class VineDensity(DensityMixin, VineBase):
     Returns
     -------
     ndarray, shape (n_samples, n_features), dtype float
-        Generated samples in the original feature scale.
+        Generated samples, in the *expanded* feature space -- the one
+        `fit` modeled, with ``n_features_in_`` columns. Dummies of an
+        expanded unordered categorical come back as separate columns
+        rather than as the original level, since a vine draw can put a
+        ``1`` in two of them at once and choosing between those is a
+        modeling decision, not an inverse.
     """
-    check_is_fitted(self, attributes=["_vine"])
+    check_is_fitted(self, attributes=["distribution_"])
     if random_state is None:
       rng = self.random_state_
     else:
@@ -166,13 +181,7 @@ class VineDensity(DensityMixin, VineBase):
 
       rng = check_random_state(random_state)
     seeds = [int(x) for x in rng.randint(0, 2**31 - 1, size=5)]
-    U_sampled = np.asarray(
-      self.backend_.sample(self._vine, n_samples, seeds=seeds)
-    )
-    X_sampled = np.empty((n_samples, self.n_features_in_))
-    for j in range(self.n_features_in_):
-      X_sampled[:, j] = self._x_kde1d[j].icdf(U_sampled[:, j])
-    return X_sampled
+    return np.asarray(self.distribution_.sample(n_samples, seeds=seeds))
 
   def pdf(self, X: np.ndarray, copula_only: bool = False) -> np.ndarray:
     """Evaluates the joint density at the given samples.
@@ -232,9 +241,8 @@ class VineDensity(DensityMixin, VineBase):
         `N` if the MC noise floor is significant for your
         application.
     """
-    check_is_fitted(self, attributes=["_vine"])
+    check_is_fitted(self, attributes=["distribution_"])
     X = self._validate_input(X, reset=False)
-    U = self._to_u_scale(X)
     if random_state is None:
       rng = self.random_state_
     else:
@@ -242,7 +250,9 @@ class VineDensity(DensityMixin, VineBase):
 
       rng = check_random_state(random_state)
     seeds = [int(x) for x in rng.randint(0, 2**31 - 1, size=5)]
-    return np.asarray(self.backend_.cdf(self._vine, U, N=N, seeds=seeds))
+    return np.asarray(
+      self.distribution_.cdf(np.asarray(X, dtype=float), N=N, seeds=seeds)
+    )
 
 
 VineDensity.__doc__ = f"""Vine-copula based density estimator.

--- a/src/pyvinecopulib/sklearn/regressor.py
+++ b/src/pyvinecopulib/sklearn/regressor.py
@@ -1,7 +1,12 @@
+import math
+from numbers import Integral
+
 import numpy as np
 from sklearn.base import RegressorMixin
+from sklearn.utils._param_validation import Interval
 from sklearn.utils.validation import check_is_fitted
 
+from ..core import Vinedist
 from ._base import (
   _DOC_DISCRETE,
   _DOC_FACTORIZATION,
@@ -9,6 +14,13 @@ from ._base import (
   _DOC_REFERENCES,
   VineBase,
 )
+
+# Half-width, in standard deviations, of the probit substitution behind the
+# quadrature nodes: the outermost node sits at Phi(-a), so this is how far into
+# the response's tails the rule reaches. Five leaves 3e-7 of the probability
+# mass outside the grid, worth about 1e-5 response standard deviations on the
+# conditional mean; three leaves enough out to cost 3e-2 of one.
+_PROBIT_HALF_WIDTH = 5.0
 
 
 class VineRegressor(RegressorMixin, VineBase):
@@ -18,6 +30,7 @@ class VineRegressor(RegressorMixin, VineBase):
     "mean": ["boolean"],
     "quantiles": ["array-like", None],
     "use_grid": ["boolean"],
+    "n_nodes": [Interval(Integral, 2, None, closed="left")],
     "normalize_weights": ["boolean"],
   }
 
@@ -26,8 +39,10 @@ class VineRegressor(RegressorMixin, VineBase):
     mean: bool = True,
     quantiles=None,
     backend=None,
+    margins=None,
     batch_size: int = 100,
     use_grid: bool = True,
+    n_nodes: int = 401,
     normalize_weights: bool = True,
     random_state=None,
     n_jobs=None,
@@ -53,15 +68,35 @@ class VineRegressor(RegressorMixin, VineBase):
         pre-specified structure on ``(Y, X_1, ..., X_d)`` (`Y`
         always in the first dimension). `None` resolves to a default
         ``VinecopBackend`` with the ``tll`` pair family at fit time.
+    margins : object, default=None
+        The marginal half of the model, in any form
+        :func:`pyvinecopulib.margins.resolve_margins` accepts. `None`
+        fits a ``Kde1d`` per column. The specification addresses
+        the covariates; one that broadcasts (an alias, a single margin,
+        a callable) applies to the response as well. The response
+        margin must be continuous, and any such margin works with
+        either `use_grid` setting.
     batch_size : int, default=100
         Number of test points processed per batch in `predict`.
     use_grid : bool, default=True
-        Controls how training responses are represented for the
-        weighted-sample predictor. ``False`` uses importance
-        weighting over training rows with
-        :math:`w_i(x) \\propto c_{Y,X}(\\hat F_Y(y_i),
-        \\hat F_X(x))`. ``True`` (default) uses the Kde1d grid
-        points and an extra :math:`\\hat f_Y(y_g)` factor.
+        Where the response values entering the weighted statistic
+        come from. ``True`` (default) evaluates
+        :math:`\\mathbb{E}[Y \\mid X = x] = \\int_0^1 \\hat
+        F_Y^{-1}(p)\\, c_{Y,X}(p, \\hat F_X(x))\\, dp` on a fixed
+        grid of `n_nodes` probability levels, which costs the same
+        whatever the sample size. ``False`` sums over the training
+        rows instead, with
+        :math:`w_i(x) \\propto c_{Y,X}(\\hat F_Y(y_i), \\hat
+        F_X(x))` -- the same integral approximated by Monte Carlo,
+        which in exchange cannot reach past the largest observed
+        response.
+    n_nodes : int, default=401
+        Number of quadrature nodes when ``use_grid=True``, ignored
+        otherwise. The default keeps the quadrature error on the
+        conditional mean near 1e-5 response standard deviations, well
+        under the model's own error; predicted quantiles are resolved
+        to about one node spacing, so raise it when they are the
+        output of interest.
     normalize_weights : bool, default=True
         If ``True`` (default), per-row weights produced by
         `_iter_weights` are rescaled to sum to one. Set to
@@ -85,6 +120,7 @@ class VineRegressor(RegressorMixin, VineBase):
     """
     super().__init__(
       backend=backend,
+      margins=margins,
       batch_size=batch_size,
       random_state=random_state,
       n_jobs=n_jobs,
@@ -92,6 +128,7 @@ class VineRegressor(RegressorMixin, VineBase):
     self.mean = mean
     self.quantiles = quantiles
     self.use_grid = use_grid
+    self.n_nodes = n_nodes
     self.normalize_weights = normalize_weights
 
   def fit(self, X: np.ndarray, y: np.ndarray) -> "VineRegressor":
@@ -132,23 +169,59 @@ class VineRegressor(RegressorMixin, VineBase):
     else:
       self.quantiles_ = None
     self._fit_marginals(X, y)
+    if getattr(self._y_margin, "supports_covariates", False):
+      raise ValueError(
+        "VineRegressor cannot use a conditional response margin "
+        f"({type(self._y_margin).__name__} declares supports_covariates): the "
+        "quadrature inverts one shared probability grid, which a margin whose "
+        "quantiles move with the covariates turns into one grid per test row."
+      )
 
     uy_train = self._to_u_scale(y, is_y=True)
     ux = self._to_u_scale(X)
 
-    assert self.schema_ is not None
-    var_types = ["c"] + [x[0] for x in self.schema_["kde1d_types"]]
+    # The response leads the joint model, and being continuous it adds no
+    # left-limit column, so its `u` column simply prepends to the covariates'
+    # own layout.
+    margins = (self._y_margin, *self._x_margins)
+    var_types = Vinedist.copula_var_types(margins)
     self._fit_vine(np.column_stack([uy_train, ux]), var_types=var_types)
+    self._bind_distribution(margins)
 
     if not self.use_grid:
-      self._y_train = y
-      self._uy_train = uy_train
+      self._u_nodes = uy_train
+      self._y_nodes = y
+      self._node_weights = None
     else:
-      self._y_train = self._y_kde1d.grid_points
-      uy_cdf = self._y_kde1d.cdf(self._y_train)
-      self._uy_train = np.asarray(uy_cdf).reshape(-1, 1)
-      self._y_density = self._y_kde1d.values[np.newaxis, :]
+      p_nodes, node_weights = self._probability_grid()
+      self._u_nodes = p_nodes.reshape(-1, 1)
+      self._y_nodes = np.asarray(
+        self._y_margin.icdf(p_nodes), dtype=float
+      ).ravel()
+      self._node_weights = node_weights
     return self
+
+  def _probability_grid(self) -> tuple[np.ndarray, np.ndarray]:
+    """Quadrature nodes on ``(0, 1)``, and their weights.
+
+    The rule integrates
+    :math:`\\int_0^1 F_Y^{-1}(p)\\, c(p, u_x)\\, dp` under the
+    substitution :math:`p = \\Phi(z)` on a uniform ``z`` grid, which
+    spends nodes on the tails of the response rather than on the bulk
+    of its probability scale.
+
+    Returns
+    -------
+    p : ndarray, shape (n_nodes,), dtype float
+        Increasing probability levels, all strictly inside ``(0, 1)``.
+    dp : ndarray, shape (1, n_nodes), dtype float
+        Node weights :math:`dp/dz`, up to the constant factor the
+        row normalization absorbs.
+    """
+    z = np.linspace(-_PROBIT_HALF_WIDTH, _PROBIT_HALF_WIDTH, int(self.n_nodes))
+    root_two = math.sqrt(2.0)
+    p = np.array([0.5 * (1.0 + math.erf(zi / root_two)) for zi in z])
+    return p, np.exp(-0.5 * z**2)[np.newaxis, :]
 
   def _copula_marginal_density(
     self, X: np.ndarray, log: bool = False, n_grid: int = 101
@@ -214,20 +287,19 @@ class VineRegressor(RegressorMixin, VineBase):
     Single source of truth for the weight math: `_iter_weights` is
     the batched generator over it and `_predict_from_iter` the
     consumer. Kept as a separate, directly callable seam so external
-    code can reuse the exact weight definition. For each row computes
+    code can reuse the exact weight definition. Each weight pairs one
+    node :math:`y_k` -- a training response when ``use_grid=False``,
+    else :math:`\\hat F_Y^{-1}(p_k)` -- with
 
     .. math::
 
-       w_i(x) \\propto
-       \\begin{cases}
-         c_{Y, X}\\bigl(\\hat F_Y(y_i), \\hat F_X(x)\\bigr) &
-            \\text{if } \\texttt{use\\_grid = False}, \\\\
-         c_{Y, X}\\bigl(\\hat F_Y(y_g), \\hat F_X(x)\\bigr)\\,
-         \\hat f_Y(y_g) &
-            \\text{if } \\texttt{use\\_grid = True},
-       \\end{cases}
+       w_k(x) \\propto
+       c_{Y, X}\\bigl(u_k, \\hat F_X(x)\\bigr) \\cdot \\Delta_k,
 
-    row-normalized when ``normalize_weights=True``.
+    where :math:`u_k` is :math:`\\hat F_Y(y_k)` over training rows
+    and :math:`p_k` on the probability grid, and :math:`\\Delta_k` is
+    the node spacing there (constant, hence absent, over training
+    rows). Row-normalized when ``normalize_weights=True``.
 
     Parameters
     ----------
@@ -236,19 +308,19 @@ class VineRegressor(RegressorMixin, VineBase):
 
     Returns
     -------
-    w : ndarray, shape (batch, n_train_or_grid), dtype float
+    w : ndarray, shape (batch, n_nodes), dtype float
         Per-row weights for the batch.
     """
     ux_batch_rows = self._to_u_scale(np.asarray(X_batch))
     m = ux_batch_rows.shape[0]
-    n_train = self._y_train.shape[0]
-    ux_batch = np.repeat(ux_batch_rows, n_train, axis=0)
-    uy_rep = np.tile(self._uy_train, (m, 1)).reshape(-1, 1)
+    n_nodes = self._y_nodes.shape[0]
+    ux_batch = np.repeat(ux_batch_rows, n_nodes, axis=0)
+    uy_rep = np.tile(self._u_nodes, (m, 1)).reshape(-1, 1)
     u_test = np.column_stack([uy_rep, ux_batch])
 
-    w = np.asarray(self.backend_.pdf(self._vine, u_test)).reshape(m, n_train)
-    if self.use_grid:
-      w *= self._y_density
+    w = np.asarray(self.backend_.pdf(self._vine, u_test)).reshape(m, n_nodes)
+    if self._node_weights is not None:
+      w = w * self._node_weights
     if self.normalize_weights:
       w /= np.sum(w, axis=1, keepdims=True)
     return w
@@ -266,7 +338,7 @@ class VineRegressor(RegressorMixin, VineBase):
 
     Yields
     ------
-    w : ndarray, shape (batch, n_train_or_grid), dtype float
+    w : ndarray, shape (batch, n_nodes), dtype float
         Per-row weights for the current batch.
     start : int
         Index of the first row in the batch.
@@ -280,7 +352,7 @@ class VineRegressor(RegressorMixin, VineBase):
       yield self._weights_for_batch(X[start:end]), start, end
 
   def _predict_from_iter(self, X, iter_weights):
-    """Combines batched weights with training responses to form predictions.
+    """Combines batched weights with the response nodes into predictions.
 
     Parameters
     ----------
@@ -310,12 +382,12 @@ class VineRegressor(RegressorMixin, VineBase):
     for w, start, end in iter_weights(X):
       col = 0
       if self.mean:
-        y_pred[start:end, col] = w @ self._y_train
+        y_pred[start:end, col] = w @ self._y_nodes
         col += 1
       if quantiles is not None:
         batch_preds = [
           np.quantile(
-            a=self._y_train,
+            a=self._y_nodes,
             q=quantiles,
             weights=row_w,
             method="inverted_cdf",
@@ -331,9 +403,10 @@ class VineRegressor(RegressorMixin, VineBase):
   def predict(self, X):
     """Predicts the conditional mean and/or quantiles of ``Y`` given ``X``.
 
-    Computes weights :math:`w_i(x)` from the fitted copula
-    (`_iter_weights`) and returns the weighted statistics:
-    :math:`\\hat{\\mathbb{E}}[Y \\mid X = x] = \\sum_i w_i(x)\\, y_i`
+    Computes weights :math:`w_k(x)` from the fitted copula
+    (`_iter_weights`) and returns the weighted statistics over the
+    response nodes :math:`y_k`:
+    :math:`\\hat{\\mathbb{E}}[Y \\mid X = x] = \\sum_k w_k(x)\\, y_k`
     for the mean (closed-form solution of the estimating equation
     :math:`\\int (y - \\beta) \\hat f(y \\mid x)\\, dy = 0`) and the
     weighted quantile via :func:`numpy.quantile` with

--- a/tests/test_sklearn_backends.py
+++ b/tests/test_sklearn_backends.py
@@ -219,7 +219,10 @@ class TestEstimatorWiring:
 
   def test_fit_sets_schema_underscore(self, small_data):
     est = VineDensity().fit(small_data)
-    assert est.schema_ == {"kde1d_types": ["continuous"] * 3}
+    assert est.schema_ == {
+      "kde1d_types": ["continuous"] * 3,
+      "bounds": [None] * 3,
+    }
 
   def test_fit_sets_structure_underscore(self, small_data):
     est = VineDensity().fit(small_data)
@@ -370,3 +373,28 @@ class TestNJobs:
     assert copy.deepcopy(VineDensity(n_jobs=3)).n_jobs == 3
     with pytest.raises(InvalidParameterError):
       VineDensity(n_jobs="all").fit(X)
+
+
+def test_the_fitted_distribution_samples_through_the_backend():
+  """Every evaluation route must go through the backend that fitted the vine.
+
+  The wrapper forwards unknown attributes to the raw vine, so a method it does
+  not define is answered by the vine directly — skipping the backend's own
+  conversion of its result. `sample` is the one that would then return whatever
+  the vine's array namespace produces.
+  """
+  rng = np.random.default_rng(0)
+  X = rng.multivariate_normal([0.0, 0.0], [[1.0, 0.6], [0.6, 1.0]], size=200)
+  est = VineDensity().fit(X)
+
+  seen = []
+  original = est.backend_.sample
+
+  def spy(vine, n_samples, *, seeds):
+    seen.append(n_samples)
+    return original(vine, n_samples, seeds=seeds)
+
+  est.backend_.sample = spy
+  drawn = est.sample(5, random_state=1)
+  assert seen == [5]
+  assert isinstance(drawn, np.ndarray) and drawn.shape == (5, 2)

--- a/tests/test_sklearn_base.py
+++ b/tests/test_sklearn_base.py
@@ -158,6 +158,12 @@ def test_vinebase_schema_attribute(
   with pytest.raises(ValueError):
     density_wrong._validate_input(X, reset=True)
 
+  # So does a pre-set bounds list of the wrong length.
+  density_bounds = VineDensity()
+  density_bounds.schema_ = {"bounds": [(0.0, 1.0)]}  # Too short
+  with pytest.raises(ValueError, match="bounds"):
+    density_bounds._validate_input(X, reset=True)
+
 
 def test_vinebase_marginal_fitting(
   sample_array_data: tuple[np.ndarray, np.ndarray, np.ndarray],
@@ -170,9 +176,8 @@ def test_vinebase_marginal_fitting(
   density._fit_marginals(X_processed)
 
   # Check that marginals are fitted
-  assert len(density._x_kde1d) == 2
-
-  assert all(hasattr(kde, "fit") for kde in density._x_kde1d)
+  assert len(density._x_margins) == 2
+  assert all(margin.is_fitted for margin in density._x_margins)
 
 
 def test_vinebase_pseudoobservations(

--- a/tests/test_sklearn_check_estimator.py
+++ b/tests/test_sklearn_check_estimator.py
@@ -6,7 +6,7 @@ opted out of. The skip list captures two categories:
 
 - **Genuine opt-outs**: checks that don't apply to a joint-density /
   vine-regressor archetype (sparse inputs, 1-D / 1-feature degenerate
-  cases, complex-valued data, etc.).
+  cases, etc.).
 - **Known WIP**: checks that surface real sklearn-compliance gaps the
   initial backend-refactor PR did not fix. Listed with ``TODO``
   comments so future PRs can address them and shrink this list.
@@ -50,9 +50,7 @@ _GENUINE_OPT_OUTS = {
   "check_fit2d_1sample": "Kde1d requires >= 2 samples to estimate a bandwidth",
   "check_fit1d": "vines require 2-D U-scale data",
   "check_fit2d_predict1d": "predict requires 2-D inputs",
-  "check_complex_data": "complex inputs not supported",
   "check_estimators_dtypes": "internal float64 promotion is intentional",
-  "check_dtype_object": "internal float64 promotion is intentional",
   "check_estimators_empty_data_messages": (
     "empty data error messages — TODO: surface a sklearn-shaped error early"
   ),

--- a/tests/test_sklearn_density.py
+++ b/tests/test_sklearn_density.py
@@ -51,9 +51,9 @@ def test_fit_properties(fitted_density):
   """Test properties after fitting."""
   density, _ = fitted_density
   assert hasattr(density, "_vine")
-  assert hasattr(density, "_x_kde1d")
   assert density.n_features_in_ == 2
-  assert len(density._x_kde1d) == 2
+  assert density.distribution_.dim == 2
+  assert len(density.distribution_.margins) == 2
 
 
 def test_score_samples_shapes_and_types(fitted_density):

--- a/tests/test_sklearn_margins.py
+++ b/tests/test_sklearn_margins.py
@@ -1,0 +1,347 @@
+"""Tests for the ``margins=`` half of the sklearn estimators.
+
+What this file pins is the delegation. That an estimator *is* a `Vinedist` --
+the same layout, the same log-density, the same draws -- rather than a second
+implementation of Sklar's theorem that can drift from the first. That
+`margins=None` still means what it meant before margins were configurable: a
+`Kde1d` per column, to the last bit. That a specification the caller gives is
+honored per column and never mutated, so `clone` reproduces the estimator. And
+that the ``{0, 1}`` dummies of an expanded unordered categorical are fitted on
+the support they actually have, rather than on a padded grid that puts mass on
+values that cannot occur.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+pytest.importorskip("sklearn")
+pytest.importorskip("pandas")
+
+import pandas as pd  # noqa: E402  (import order: after the availability check)
+
+from sklearn.base import clone  # noqa: E402
+
+import pyvinecopulib as pv  # noqa: E402
+from pyvinecopulib.core import Kde1d  # noqa: E402
+from pyvinecopulib.margins import (  # noqa: E402
+  EmpiricalMargin,
+  MarginSelector,
+  ParametricMargin,
+)
+from pyvinecopulib.sklearn import VineDensity, VineRegressor  # noqa: E402
+
+# --- the default is the old pipeline ---------------------------------------- #
+
+
+def test_default_margins_reproduce_the_kde1d_pipeline(
+  sample_array_data: tuple[np.ndarray, np.ndarray, np.ndarray],
+) -> None:
+  """`margins=None` is the pre-margins pipeline, to floating-point rounding."""
+  X, _, _ = sample_array_data
+  eps = 1e-10
+  kdes = []
+  for j in range(X.shape[1]):
+    kde = pv.core.Kde1d()
+    kde.fit(X[:, j])
+    kdes.append(kde)
+
+  def transform(z: np.ndarray) -> np.ndarray:
+    return np.column_stack(
+      [np.clip(k.cdf(z[:, j]), eps, 1 - eps) for j, k in enumerate(kdes)]
+    )
+
+  vine = pv.Vinecop.from_data(
+    data=transform(X),
+    var_types=["c"] * X.shape[1],
+    controls=pv.FitControlsVinecop(
+      family_set=[pv.families.tll], trunc_lvl=20, num_threads=1
+    ),
+  )
+  head = X[:20]
+  expected = np.log(np.asarray(vine.pdf(transform(head)))) + sum(
+    np.log(np.asarray(kdes[j].pdf(head[:, j]))) for j in range(X.shape[1])
+  )
+  got = VineDensity().fit(X).score_samples(head)
+  np.testing.assert_allclose(got, expected, rtol=1e-12, atol=1e-14)
+
+
+# --- the fitted distribution ------------------------------------------------ #
+
+
+def test_fit_publishes_the_distribution(
+  sample_array_data: tuple[np.ndarray, np.ndarray, np.ndarray],
+) -> None:
+  """`distribution_` is the fitted model, and agrees with the estimator."""
+  X, _, _ = sample_array_data
+  est = VineDensity().fit(X)
+  assert isinstance(est.distribution_, pv.Vinedist)
+  assert est.distribution_.dim == est.n_features_in_
+  np.testing.assert_allclose(est.distribution_.pdf(X[:10]), est.pdf(X[:10]))
+  np.testing.assert_allclose(
+    est.distribution_.sample(5, seeds=[1, 2, 3]).shape, (5, 2)
+  )
+
+
+def test_the_held_copula_still_answers_as_the_vine(
+  sample_array_data: tuple[np.ndarray, np.ndarray, np.ndarray],
+) -> None:
+  """Wrapping the vine for the backend does not hide the vine's own surface."""
+  X, _, _ = sample_array_data
+  est = VineDensity().fit(X)
+  copula = est.distribution_.copula
+  assert copula.dim == est.n_features_in_
+  assert copula.var_types == ["c", "c"]
+  np.testing.assert_array_equal(
+    np.asarray(copula.structure.matrix), np.asarray(est.structure_.matrix)
+  )
+  np.testing.assert_allclose(
+    np.asarray(copula.pdf(est._to_u_scale(X[:10]))),
+    est.pdf(X[:10], copula_only=True),
+  )
+
+
+def test_joint_distribution_of_the_regressor_leads_with_the_response(
+  regression_data: tuple[np.ndarray, np.ndarray, np.ndarray, float],
+) -> None:
+  """The regressor's distribution is over ``(Y, X)``, the response first."""
+  X, y, _, _ = regression_data
+  est = VineRegressor().fit(X, y)
+  assert est.distribution_.dim == X.shape[1] + 1
+  np.testing.assert_allclose(
+    est.distribution_.logpdf(np.column_stack([y[:10], X[:10]])),
+    est._pdf_samples(X[:10], y=y[:10], log=True),
+  )
+
+
+# --- bounds of an expanded dummy -------------------------------------------- #
+
+
+def test_expanded_dummies_are_fitted_on_their_own_support(
+  sample_dataframe_data: tuple[pd.DataFrame, list[str]],
+) -> None:
+  """A ``{0, 1}`` dummy is bounded, so no mass lands on an impossible value."""
+  X_df, expanded = sample_dataframe_data
+  est = VineDensity().fit(X_df)
+  dummies = [j for j, name in enumerate(expanded) if name.startswith("cat1_")]
+  assert dummies
+  for j in dummies:
+    # `support` / `var_type` / `is_fitted` are optional capabilities, not
+    # members of `MarginLike`, so they are read off a loosely typed binding.
+    margin: Any = est.distribution_.margins[j]
+    assert margin.support == (0.0, 1.0)
+    assert margin.pdf(np.array([2.0])).item() == 0.0
+    assert margin.cdf(np.array([-1.0])).item() == 0.0
+  # A continuous column states no support, so it stays unbounded.
+  unbounded: Any = est.distribution_.margins[0]
+  assert unbounded.support == (-np.inf, np.inf)
+
+
+def test_ordered_categorical_is_fitted_on_its_declared_levels() -> None:
+  """A categorical declares its levels, so counts get no density below zero."""
+  rng = np.random.default_rng(0)
+  counts = rng.poisson(3.0, 400)
+  X_df = pd.DataFrame(
+    {
+      "cnt": pd.Categorical(counts, ordered=True),
+      "z": rng.normal(size=400),
+    }
+  )
+  est = VineDensity(random_state=0).fit(X_df)
+  assert est.schema_["bounds"][0] == (float(counts.min()), float(counts.max()))
+  margin: Any = est.distribution_.margins[0]
+  assert margin.var_type == "d"
+  assert margin.support == (float(counts.min()), float(counts.max()))
+  # Padding the grid below the smallest level is what put mass on impossible
+  # counts; the declared support removes it exactly rather than approximately.
+  assert margin.cdf(np.array([-1.0])).item() == 0.0
+  assert margin.pdf(np.array([-1.0])).item() == 0.0
+
+
+def test_cdf_works_with_columns_that_have_atoms(
+  sample_dataframe_data: tuple[pd.DataFrame, list[str]],
+) -> None:
+  """A copula with atoms validates the whole layout, and gets it."""
+  X_df, _ = sample_dataframe_data
+  est = VineDensity(random_state=0).fit(X_df)
+  values = est.cdf(X_df.iloc[:10])
+  assert values.shape == (10,)
+  assert np.all((values >= 0.0) & (values <= 1.0))
+
+
+def test_sample_returns_the_expanded_feature_space(
+  sample_dataframe_data: tuple[pd.DataFrame, list[str]],
+) -> None:
+  """Dummies come back as columns: collapsing them is not an inverse."""
+  X_df, expanded = sample_dataframe_data
+  est = VineDensity(random_state=0).fit(X_df)
+  drawn = est.sample(20, random_state=1)
+  assert drawn.shape == (20, len(expanded))
+  j = expanded.index("cat1_B")
+  assert set(np.unique(drawn[:, j])) <= {0.0, 1.0}
+
+
+# --- specifications --------------------------------------------------------- #
+
+
+def test_fit_does_not_mutate_the_margins_argument(
+  sample_array_data: tuple[np.ndarray, np.ndarray, np.ndarray],
+) -> None:
+  """Specifications are fitted on copies, so the parameters survive `fit`."""
+  X, _, _ = sample_array_data
+  spec = Kde1d()
+  est = VineDensity(margins=spec).fit(X)
+  assert est.get_params()["margins"] is spec
+  assert not spec.is_fitted
+  fitted: tuple[Any, ...] = est.distribution_.margins
+  assert all(margin.is_fitted for margin in fitted)
+  # Refitting therefore re-estimates rather than reusing the first fit.
+  est.fit(X[:100])
+  assert not spec.is_fitted
+
+
+def test_clone_round_trips_the_margins_parameter(
+  sample_array_data: tuple[np.ndarray, np.ndarray, np.ndarray],
+) -> None:
+  """`clone` reproduces an estimator that fits the same margins."""
+  X, _, _ = sample_array_data
+  est = VineDensity(margins="parametric").fit(X)
+  cloned = clone(est)
+  assert cloned.margins == "parametric"
+  np.testing.assert_allclose(
+    cloned.fit(X).score_samples(X[:10]), est.score_samples(X[:10])
+  )
+
+
+def test_a_density_less_margin_is_refused_at_fit_time(
+  sample_array_data: tuple[np.ndarray, np.ndarray, np.ndarray],
+) -> None:
+  """Empirical margins have no density, so scoring on them cannot work.
+
+  Caught at `fit`, not at the first `score_samples`, so the estimator never
+  reaches a state where its own contract cannot be met.
+  """
+  X, _, _ = sample_array_data
+  with pytest.raises(ValueError, match="needs a density"):
+    VineDensity(margins="empirical").fit(X)
+  with pytest.raises(ValueError, match="Kde1d"):
+    VineDensity(margins=EmpiricalMargin()).fit(X)
+  # `VineRegressor` reads the copula density and the response `icdf` only, so
+  # the same margin is fine there.
+  VineRegressor(margins=EmpiricalMargin(), use_grid=False).fit(X, X[:, 0])
+
+
+def test_a_wrong_length_sequence_is_refused(
+  sample_array_data: tuple[np.ndarray, np.ndarray, np.ndarray],
+) -> None:
+  """A per-column sequence must carry one entry per column."""
+  X, _, _ = sample_array_data
+  with pytest.raises(ValueError, match="length 1, but there are 2"):
+    VineDensity(margins=[Kde1d()]).fit(X)
+
+
+def test_a_mapping_leaves_the_other_columns_on_the_inferred_default(
+  sample_dataframe_data: tuple[pd.DataFrame, list[str]],
+) -> None:
+  """Addressing one column must not silently retype the rest."""
+  X_df, expanded = sample_dataframe_data
+  est = VineDensity(margins={"cont1": ParametricMargin("norm")}).fit(X_df)
+  margins = est.distribution_.margins
+  assert isinstance(margins[0], ParametricMargin)
+  dummy: Any = margins[expanded.index("cat1_B")]
+  assert isinstance(dummy, Kde1d)
+  assert dummy.var_type == "d"
+  assert dummy.support == (0.0, 1.0)
+
+
+def test_a_preset_schema_supplies_what_an_array_cannot_carry() -> None:
+  """`schema_` declares per-column variable types and bounds before `fit`."""
+  rng = np.random.default_rng(0)
+  X = np.column_stack([rng.poisson(3.0, size=200) * 1.0, rng.normal(size=200)])
+  est = VineDensity()
+  est.schema_ = {
+    "kde1d_types": ["discrete", "continuous"],
+    "bounds": [(0.0, 20.0), None],
+  }
+  est.fit(X)
+  counts: Any = est.distribution_.margins[0]
+  assert counts.var_type == "d"
+  assert counts.support == (0.0, 20.0)
+  assert est.distribution_.var_types == ["d", "c"]
+
+
+def test_a_fixed_foreign_margin_is_used_as_given(
+  sample_array_data: tuple[np.ndarray, np.ndarray, np.ndarray],
+) -> None:
+  """An already-fitted margin is not re-estimated."""
+  stats = pytest.importorskip("scipy.stats")
+  X, _, _ = sample_array_data
+  est = VineDensity(margins=[stats.norm(0.0, 1.0), stats.norm(0.0, 1.0)]).fit(X)
+  np.testing.assert_allclose(
+    np.asarray(est.distribution_.margins[0].cdf(np.array([0.0]))), 0.5
+  )
+
+
+# --- family selection ------------------------------------------------------- #
+
+
+def test_selection_report_is_empty_without_a_selector(
+  sample_array_data: tuple[np.ndarray, np.ndarray, np.ndarray],
+) -> None:
+  """Nothing selected a family, so the table is empty rather than absent."""
+  X, _, _ = sample_array_data
+  assert VineDensity().fit(X).selection_report_ == []
+
+
+def test_parametric_margins_report_their_selection(
+  sample_array_data: tuple[np.ndarray, np.ndarray, np.ndarray],
+) -> None:
+  """`margins="parametric"` selects per column and names the column it fitted."""
+  pytest.importorskip("scipy")
+  X, _, _ = sample_array_data
+  est = VineDensity(margins="parametric").fit(X)
+  assert all(isinstance(m, MarginSelector) for m in est.distribution_.margins)
+  assert {row["column"] for row in est.selection_report_} == {"x0", "x1"}
+  assert "selected" in {row["status"] for row in est.selection_report_}
+
+
+def test_selection_report_names_dataframe_columns(
+  sample_dataframe_data: tuple[pd.DataFrame, list[str]],
+) -> None:
+  """With named features, the report is keyed by the expanded column name."""
+  pytest.importorskip("scipy")
+  X_df, expanded = sample_dataframe_data
+  est = VineDensity(margins="parametric").fit(X_df)
+  assert {row["column"] for row in est.selection_report_} == set(expanded)
+
+
+# --- the response margin ---------------------------------------------------- #
+
+
+def test_the_response_margin_follows_a_broadcast_specification(
+  regression_data: tuple[np.ndarray, np.ndarray, np.ndarray, float],
+) -> None:
+  """An alias covers the response too; a per-column sequence does not."""
+  X, y, _, _ = regression_data
+  broadcast = VineRegressor(margins="empirical").fit(X, y)
+  assert isinstance(broadcast.distribution_.margins[0], EmpiricalMargin)
+
+  per_column = VineRegressor(
+    margins=[EmpiricalMargin(), EmpiricalMargin()]
+  ).fit(X, y)
+  assert isinstance(per_column.distribution_.margins[0], Kde1d)
+  assert isinstance(per_column.distribution_.margins[1], EmpiricalMargin)
+
+
+def test_a_discrete_response_margin_is_refused(
+  regression_data: tuple[np.ndarray, np.ndarray, np.ndarray, float],
+) -> None:
+  """The joint layout leads with the response and gives it no left limit."""
+  X, y, _, _ = regression_data
+  with pytest.raises(ValueError, match="response margin must be continuous"):
+    VineRegressor(margins=Kde1d(type="discrete"), use_grid=False).fit(
+      X, np.round(y)
+    )

--- a/tests/test_sklearn_regressor.py
+++ b/tests/test_sklearn_regressor.py
@@ -36,10 +36,9 @@ def test_fit_properties(fitted_regressor):
   """Test properties after fitting."""
   regressor, _, _, _, _, _ = fitted_regressor
   assert hasattr(regressor, "_vine")
-  assert hasattr(regressor, "_x_kde1d")
-  assert hasattr(regressor, "_y_kde1d")
-  assert hasattr(regressor, "_y_train")
   assert regressor.n_features_in_ == 2
+  # The joint distribution is over (Y, X), the response first.
+  assert regressor.distribution_.dim == 3
 
 
 def test_predict_mean_only(regression_setup):
@@ -137,6 +136,8 @@ def test_invalid_configuration(regression_setup):
   [
     ({"mean": "yes"}, TypeError),
     ({"use_grid": 1}, TypeError),
+    ({"n_nodes": 1}, ValueError),
+    ({"n_nodes": 12.5}, TypeError),
     ({"batch_size": 0}, ValueError),
     ({"batch_size": -3}, ValueError),
     ({"batch_size": 1.5}, TypeError),
@@ -180,7 +181,7 @@ def test_normalize_weights_parameter(regression_setup):
   pred_raw = reg_raw.predict(X_test)
 
   # With normalized weights, rows sum to 1 and the prediction is a
-  # convex combination of training responses; without normalization it
+  # convex combination of the response nodes; without normalization it
   # picks up the absolute scale of the copula density, so outputs
   # generally differ.
   assert not np.allclose(pred_default, pred_raw)

--- a/tests/test_sklearn_regressor_quadrature.py
+++ b/tests/test_sklearn_regressor_quadrature.py
@@ -1,0 +1,213 @@
+"""Tests for ``VineRegressor``'s quadrature over the response.
+
+What this file pins is where the nodes come from. ``use_grid=True`` integrates
+on the probability scale --- nodes at ``margin.icdf(p)``, weights the copula
+density alone --- so the rule asks the response margin for nothing but its
+inverse CDF: every continuous margin can be the response, the nodes cannot
+leave its support, and a bounded margin is no less accurate than an unbounded
+one. It also pins the arithmetic: the weights carry the node spacing and *not*
+the marginal density, which is what makes the substitution correct.
+
+The reference throughout is ``use_grid=False``, the exact weighted sum over the
+training rows, which approximates the same integral by Monte Carlo and shares no
+code with the quadrature.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+pytest.importorskip("sklearn")
+
+import pyvinecopulib as pv  # noqa: E402
+from pyvinecopulib.core import Kde1d  # noqa: E402
+from pyvinecopulib.margins import (  # noqa: E402
+  EmpiricalMargin,
+)
+from pyvinecopulib.sklearn import VineRegressor  # noqa: E402
+
+BETA = np.array([1.0, -0.7])
+
+
+def _data(n: int, seed: int = 20260818, heavy: bool = False):
+  """Covariates and a linear response, optionally heavy-tailed."""
+  rng = np.random.default_rng(seed)
+  X = rng.standard_normal((n, 2))
+  noise = rng.standard_t(3, size=n) if heavy else rng.standard_normal(n)
+  return X, X @ BETA + 0.5 * noise
+
+
+def _bounded_kde(column: np.ndarray) -> Kde1d:
+  """A margin bounded by the observed range, so its own grid is non-uniform."""
+  column = np.asarray(column, dtype=float)
+  return Kde1d(xmin=float(column.min()), xmax=float(column.max())).fit(column)
+
+
+def _relative_rmse(a: np.ndarray, b: np.ndarray, scale: float) -> float:
+  return float(np.sqrt(np.mean((a - b) ** 2)) / scale)
+
+
+def test_the_weights_are_the_copula_density_times_the_node_spacing() -> None:
+  """No marginal density factor: the substitution to ``p`` cancels it."""
+  X, y = _data(300)
+  est = VineRegressor(n_nodes=41).fit(X, y)
+  dist = est.distribution_
+
+  # The documented rule: p = Phi(z) on a uniform z grid spanning five standard
+  # deviations either side of the median. Retuning that half-width moves this
+  # expectation with it.
+  z = np.linspace(-5.0, 5.0, 41)
+  p = np.array([0.5 * (1.0 + math.erf(zi / math.sqrt(2.0))) for zi in z])
+  nodes = np.asarray(dist.margins[0].icdf(p), dtype=float)
+  spacing = np.exp(-0.5 * z**2)
+
+  expected = []
+  for row in X[:5]:
+    ux = np.asarray(
+      pv.Vinedist.copula_data(dist.margins[1:], row.reshape(1, -1))
+    )
+    u = np.column_stack([p, np.repeat(ux, p.size, axis=0)])
+    w = np.asarray(dist.copula.pdf(u)) * spacing
+    expected.append((w / w.sum()) @ nodes)
+
+  np.testing.assert_allclose(
+    est.predict(X[:5]), np.asarray(expected), rtol=1e-12, atol=1e-12
+  )
+
+
+def test_the_node_count_is_n_nodes() -> None:
+  """``n_nodes`` sets the width of the weight matrix, whatever the sample."""
+  X, y = _data(300)
+  est = VineRegressor(n_nodes=17).fit(X, y)
+  assert est._weights_for_batch(X[:4]).shape == (4, 17)
+
+
+@pytest.mark.parametrize("heavy", [False, True])
+def test_the_quadrature_converges(heavy: bool) -> None:
+  """Refining the grid stops moving the prediction well before the default."""
+  X, y = _data(400, heavy=heavy)
+  scale = float(np.std(y))
+  fine = VineRegressor(n_nodes=4001).fit(X, y).predict(X[:25])
+  default = VineRegressor().fit(X, y).predict(X[:25])
+  coarse = VineRegressor(n_nodes=51).fit(X, y).predict(X[:25])
+
+  assert _relative_rmse(default, fine, scale) < 1e-3
+  # A coarse grid is visibly worse, so the default is not accidentally exact.
+  assert _relative_rmse(coarse, fine, scale) > _relative_rmse(
+    default, fine, scale
+  )
+
+
+def test_it_integrates_the_inverse_cdf_against_the_copula() -> None:
+  """The rule computes the integral it claims to, on an independent grid.
+
+  The expectation here is a midpoint rule uniform in ``p`` -- a different node
+  set and no probit substitution -- written out from the fitted distribution
+  alone, so agreeing with it says the estimator integrates
+  :math:`F_Y^{-1}(p)\\, c(p, u_x)` and not something proportional to it.
+  """
+  X, y = _data(400)
+  scale = float(np.std(y))
+  est = VineRegressor(n_nodes=4001).fit(X, y)
+  dist = est.distribution_
+
+  n_reference = 8001
+  p = (np.arange(n_reference) + 0.5) / n_reference
+  nodes = np.asarray(dist.margins[0].icdf(p), dtype=float)
+  expected = []
+  for row in X[:8]:
+    ux = np.asarray(
+      pv.Vinedist.copula_data(dist.margins[1:], row.reshape(1, -1))
+    )
+    u = np.column_stack([p, np.repeat(ux, n_reference, axis=0)])
+    w = np.asarray(dist.copula.pdf(u))
+    expected.append((w / w.sum()) @ nodes)
+
+  assert _relative_rmse(est.predict(X[:8]), np.asarray(expected), scale) < 1e-4
+
+
+def test_the_quadrature_agrees_with_the_exact_weighted_sum() -> None:
+  """Both paths estimate the same integral, so they must nearly agree."""
+  X, y = _data(2000)
+  scale = float(np.std(y))
+  grid = VineRegressor().fit(X, y).predict(X[:25])
+  exact = VineRegressor(use_grid=False).fit(X, y).predict(X[:25])
+  # The bound is the Monte-Carlo error of the weighted sum, whose effective
+  # sample size is a fraction of `n`; the quadrature's own error is three
+  # orders smaller (`test_it_integrates_the_inverse_cdf_against_the_copula`).
+  assert _relative_rmse(grid, exact, scale) < 0.05
+
+
+def test_the_grid_reaches_past_the_observed_responses() -> None:
+  """A heavy-tailed response makes the two paths differ, by design.
+
+  The quadrature integrates over the whole probability scale, so it sees the
+  response margin wherever the margin extrapolates; the weighted sum over
+  training rows cannot go past the largest observation. The two therefore
+  disagree by more than Monte-Carlo error on heavy tails -- and it is not
+  quadrature error, which is what refining the grid here shows.
+  """
+  X, y = _data(2000, heavy=True)
+  scale = float(np.std(y))
+  default = VineRegressor().fit(X, y).predict(X[:25])
+  fine = VineRegressor(n_nodes=4001).fit(X, y).predict(X[:25])
+  exact = VineRegressor(use_grid=False).fit(X, y).predict(X[:25])
+
+  assert _relative_rmse(default, fine, scale) < 1e-3
+  assert _relative_rmse(default, exact, scale) > 0.01
+
+
+def test_a_bounded_response_margin_is_as_accurate_as_an_unbounded_one() -> None:
+  """Bounding the response leaves the quadrature where it was.
+
+  A bounded ``Kde1d`` grids its own support non-uniformly, which is what
+  made reading nodes and a density off that grid a biased rule.
+  """
+  X, y = _data(1500)
+  scale = float(np.std(y))
+  exact = (
+    VineRegressor(margins=_bounded_kde, use_grid=False)
+    .fit(X, y)
+    .predict(X[:25])
+  )
+  bounded = VineRegressor(margins=_bounded_kde).fit(X, y).predict(X[:25])
+  assert _relative_rmse(bounded, exact, scale) < 0.05
+
+
+def test_the_nodes_stay_inside_the_response_support() -> None:
+  """Predictions are convex combinations of points the margin can produce."""
+  X, y = _data(400)
+  est = VineRegressor(quantiles=[0.05, 0.95], margins=_bounded_kde).fit(X, y)
+  pred = est.predict(X[:50])
+  assert pred.min() >= y.min()
+  assert pred.max() <= y.max()
+
+
+@pytest.mark.parametrize("spec", ["kde", "empirical", "parametric"])
+def test_any_continuous_response_margin_works_on_the_grid(spec: str) -> None:
+  """The rule needs an inverse CDF and nothing else, so every margin serves."""
+  if spec == "parametric":
+    pytest.importorskip("scipy")
+  X, y = _data(1200)
+  scale = float(np.std(y))
+  grid = VineRegressor(margins=spec).fit(X, y).predict(X[:25])
+  exact = VineRegressor(margins=spec, use_grid=False).fit(X, y).predict(X[:25])
+  assert np.all(np.isfinite(grid))
+  # Correlation rather than a distance: a margin that extrapolates past the
+  # data legitimately moves the conditional mean away from the weighted sum
+  # (`test_the_grid_reaches_past_the_observed_responses`).
+  assert np.corrcoef(grid, exact)[0, 1] > 0.99
+  assert _relative_rmse(grid, exact, scale) < 0.2
+
+
+def test_a_step_response_margin_degenerates_to_its_atoms() -> None:
+  """An empirical margin's inverse CDF returns order statistics, so the
+  quadrature becomes a weighted sum over the observed responses."""
+  X, y = _data(300)
+  est = VineRegressor(margins=EmpiricalMargin(), n_nodes=201).fit(X, y)
+  nodes = np.asarray(est.distribution_.margins[0].icdf(np.linspace(0.01, 0.99)))
+  assert np.all(np.isin(np.round(nodes, 12), np.round(y, 12)))
+  assert np.all(np.isfinite(est.predict(X[:10])))


### PR DESCRIPTION
Second of four. `VineDensity` and `VineRegressor` stop assembling Sklar's theorem themselves and delegate the marginal half to `Vinedist` (#292), which is what makes `margins=` possible at all.

## What changes for a user

- **`margins=` on both estimators.** `None` still fits a `Kde1d` per column and reproduces the previous numbers; anything `resolve_margins` accepts works — an alias, one margin broadcast per column, a per-column sequence, a mapping keyed by variable name, or a callable.
- **`distribution_`** is the fitted `Vinedist`; `selection_report_` is the per-column family-selection table.
- **`_x_kde1d` / `_y_kde1d` are gone.** The fitted margins are `distribution_.margins`.
- `margins` sits between `backend` and `batch_size`, so a positional call past `backend` shifts.

## The regressor's quadrature moves to the probability scale

`use_grid=True` integrated over `Kde1d`'s own interpolation grid, reading `grid_points` and `values` — the tightest coupling in the repo, and the reason only a `Kde1d` could be the response margin.

Substituting `p = F_Y(y)` in the conditional expectation cancels the marginal density:

```
E[Y | X = x] = ∫ y · c(F_Y(y), u_x) · f_Y(y) dy = ∫₀¹ F_Y⁻¹(p) · c(p, u_x) dp
```

so the nodes are `icdf` of a fixed probability grid and the weights are the copula density alone. Three consequences: any continuous margin can be the response; the nodes can no longer land outside the support; and a latent bias goes away — the old weights omitted the node spacing, which is constant only when the response margin is unbounded. `n_nodes=401` replaces the implicit dependence on the KDE grid's size, and the grid is probit-spaced so the tails keep resolution.

Predictions shift by ~1e-5 response standard deviations for an unbounded response margin, and by far more for a bounded one.

## Two guards, each following from what the estimator needs

- **`VineDensity` refuses a margin with no density at `fit`**, not at the first `score_samples`. It probes rather than reads a declaration, so a margin from anywhere is caught. This is what makes `margins="empirical"` an early error with a message naming `Kde1d`.
- **`VineRegressor` keeps accepting one** — its quadrature reads the copula density and the response margin's `icdf` only, and the "step response margin degenerates to its atoms" test depends on that. What it refuses is a *conditional* response margin: the quadrature inverts one shared probability grid, which a margin whose quantiles move with the covariates would turn into one grid per test row.

## Also here

- An ordered categorical's declared support now reaches its marginal fit. Only the expanded `{0, 1}` dummies were bounded, so a count column's kernel-density grid was still padded below its smallest level.

## Verification

`make check`, `make docs`, and the sklearn / margins / `Vinedist` test files, including `parametrize_with_checks` and the `clone` round-trip.
