### PR TITLE
chore: trim the comments that repeat themselves, and delete the dead ones

### DIFF
--- a/src/pyvinecopulib/core/vinecop_base.py
+++ b/src/pyvinecopulib/core/vinecop_base.py
@@ -880,14 +880,9 @@ class VinecopBase(
   #
   # Numerically equivalent to the non-batched cascades on a simplified vine,
   # but each tree level fires one stacked pair-copula call over its edges
-  # instead of a Python loop. Only the grid state built by ``_build_batched``
-  # is subclass-specific; the loops below are array-agnostic (``xp``). The
-  # batched-vine surface used here: ``bv.level(t)`` / ``bv.grid_points`` and,
-  # per level, ``gather_inputs`` / ``pdf_h1_h2`` / ``h1_h2`` (each returning
-  # ``(N_t, n)`` slices over the ``N_t = n_pairs`` edges, fusing the shared
-  # bilinear cell search across pdf + both h-functions) plus the ``needs_h1`` /
-  # ``needs_h2`` masks. These receive already-prepped ``u`` (the public methods
-  # prep before dispatch).
+  # instead of a Python loop. Only the grid state `_build_batched` returns is
+  # subclass-specific; the loops below are array-agnostic, and receive `u`
+  # already prepped by the public method that dispatched.
   def _pdf_batched(self, u: Any) -> ArrayT:  # noqa: ANN401 - as `_pdf`
     """Batched vine pdf: product over per-tree-level stacked densities.
 
@@ -1714,15 +1709,11 @@ class VinecopBase(
       var_types: Sequence[str] = ("c", "c"),
     ) -> BicopLike[ArrayT]:
       del tree, edge
-      # `x_e` is forwarded rather than dropped: a pair class that cannot
-      # condition on covariates then refuses them -- `reject_covariates` on a
-      # `BicopBase` subclass, a `TypeError` from a compiled `Bicop`, which
-      # names no `x` at all -- instead of returning the unconditional model
-      # under a conditional name. Dropping it here is what let a
-      # non-simplified vine fit the simplified model and evaluate the
-      # conditional one. Passed only when there is one, so an unconditional
-      # vine reaches every pair class unchanged; the same rule
-      # `BicopBase.select` forwards by.
+      # Forwarded rather than dropped, so a pair class that cannot condition
+      # on covariates refuses them -- `reject_covariates` on a `BicopBase`
+      # subclass, a `TypeError` from a compiled `Bicop` -- instead of fitting
+      # the unconditional model under a conditional name. Passed only when
+      # there is one, the rule `BicopBase.select` forwards by.
       conditional = {} if x_e is None else {"x": x_e}
       return cast(
         "BicopLike[ArrayT]",

--- a/src/pyvinecopulib/sklearn/_base.py
+++ b/src/pyvinecopulib/sklearn/_base.py
@@ -480,15 +480,11 @@ class VineBase(BaseEstimator):
           "discrete" if isinstance(dtype, pd.CategoricalDtype) else "continuous"
           for dtype in X_exp.dtypes
         ]
-        # Bounds are passed wherever the input states them, and left unset
-        # wherever they would be a guess. A categorical declares its levels, so
-        # its support is known rather than assumed: an expanded name absent from
-        # the input is a {0, 1} dummy, and any other categorical is bounded by
-        # its own categories. Without this the kernel-density grid is padded
-        # past the data and puts mass on values that cannot occur -- a count
-        # column picks up density below zero. A continuous column, or a discrete
-        # one declared through a pre-set `schema_`, has no stated support and
-        # keeps `None`.
+        # Bounds are passed wherever the input states them and left unset
+        # wherever they would be a guess: a categorical declares its levels, a
+        # continuous column states nothing. Without them the kernel-density
+        # grid is padded past the data and puts mass on values that cannot
+        # occur -- a count column picks up density below zero.
         original = set(X.columns)
         bounds: list[Optional[tuple[float, float]]] = []
         for name, dtype in zip(self._expanded_columns, X_exp.dtypes):

--- a/src/pyvinecopulib/torch/vinecop.py
+++ b/src/pyvinecopulib/torch/vinecop.py
@@ -612,20 +612,14 @@ class TorchVinecop(
       )
     # Store the continuous grids; `get_pair_copula` re-wraps a discrete edge,
     # so the ModuleList holds only real nn.Modules. A thresholded edge arrives
-    # from `select` as a `core.IndependenceBicop`, which is not one -- it becomes
-    # the grid that *is* independence, whose `pdf` is exactly 1 and whose
-    # h-functions are exactly the identity, so it stores, moves and pickles like
-    # any other pair.
+    # as a `core.IndependenceBicop`, which is not one: the no-argument
+    # `TorchTllBicop` *is* independence -- a 2x2 sentinel short-circuiting
+    # every method on `is_indep`, exactly rather than to rounding -- so it
+    # needs no grid of its own and pickles like any other pair. `u_t.device`,
+    # as `fit_edge` uses: `resolved.device` is `None` whenever the caller let
+    # the data carry the placement.
     modules = [
       [
-        # A thresholded edge arrives from the engines as a
-        # `core.IndependenceBicop`, which is not an `nn.Module`. The
-        # no-argument `TorchTllBicop` *is* the independence copula -- a 2x2
-        # sentinel that short-circuits every method on `is_indep`, exactly
-        # rather than to rounding -- so it needs no grid of its own and
-        # cannot disagree with its siblings about one. `u_t.device`, as
-        # `fit_edge` uses: `resolved.device` is `None` whenever the caller
-        # let the data carry the placement.
         TorchTllBicop(device=u_t.device, dtype=eff_dtype)
         if isinstance(p, IndependenceBicop)
         else continuous_view(p)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -300,20 +300,6 @@ def regression_data(
   return X, y, true_coef, noise_std
 
 
-# # Per-test unique directory, xdist-friendly (each worker gets its own base dir)
-# @pytest.fixture(scope="function")
-# def test_dump_folder(
-#   tmp_path_factory: pytest.TempPathFactory, request: pytest.FixtureRequest
-# ) -> str:
-#   worker = os.getenv("PYTEST_XDIST_WORKER", "worker0")
-#   base = tmp_path_factory.mktemp(f"dump-{worker}")
-#   # also isolate by test node to avoid clashes inside same worker
-#   d = base / request.node.name.replace(os.sep, "_")
-#   d.mkdir(parents=True, exist_ok=True)
-#   return str(os.fspath(d))
-
-
-# If you prefer a unique file path directly:
 @pytest.fixture
 def unique_json_path(tmp_path: Path, request: pytest.FixtureRequest) -> Path:
   return tmp_path / f"{request.node.name}-{uuid.uuid4().hex}.json"

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -99,13 +99,6 @@ class TestPairCopulaData:
     ):
       pairs_copula_data(valid_data, scatter_size=0.0)
 
-    # # Test too many dimensions
-    # high_dim_data = np.random.uniform(0.1, 0.9, size=(10, 11))
-    # with pytest.raises(
-    #   ValueError, match="Dimension 11 is too large for visualization"
-    # ):
-    #   pairs_copula_data(high_dim_data)
-
     # Test too few observations
     few_obs_data = np.random.uniform(0.1, 0.9, size=(1, 2))
     with pytest.raises(ValueError, match="Need at least 2 observations, got 1"):

--- a/tests/test_sklearn_backends.py
+++ b/tests/test_sklearn_backends.py
@@ -382,13 +382,10 @@ class TestEstimatorWiring:
     assert est.random_state == 7
 
   def test_init_does_not_validate(self) -> None:
-    # Per the sklearn dev guide, ``__init__`` stores parameters
-    # as-is; out-of-range values are caught later by
-    # ``_validate_params()`` at ``fit`` time. Here we confirm
-    # construction with an invalid (but correctly-typed) value
-    # succeeds; the matching fit-time rejection is exercised in
-    # ``tests/test_sklearn_density.py::test_constructor_validation``
-    # and the regressor's analog.
+    # Per the sklearn dev guide, `__init__` stores parameters as-is and
+    # `_validate_params()` rejects them at `fit` time -- which
+    # `test_sklearn_density.py::test_constructor_validation` covers, and the
+    # regressor's analog.
     est = VineDensity(batch_size=0)
     assert est.batch_size == 0
     reg = VineRegressor(quantiles=[1.5])  # 1.5 not in (0, 1)

--- a/tests/test_sklearn_check_estimator.py
+++ b/tests/test_sklearn_check_estimator.py
@@ -52,13 +52,10 @@ _REAL_OPT_OUTS = {
 }
 
 
-# Checks that actually pass on each estimator despite living in the
-# baseline skip list. Listed here so they get popped before
-# ``parametrize_with_checks`` sees the dict — otherwise pytest emits
-# XPASS noise. Shrink the per-estimator list as the underlying check
-# semantics shift across sklearn versions; the matching baseline
-# entries can move into ``_REAL_OPT_OUTS`` once the pass is
-# universal.
+# Checks that pass despite living in the baseline skip list, popped before
+# `parametrize_with_checks` sees the dict so pytest emits no XPASS noise.
+# Shrink these as sklearn's check semantics shift; a baseline entry moves into
+# `_REAL_OPT_OUTS` once every estimator passes it.
 _KNOWN_PASSING_PER_ESTIMATOR: dict[str, tuple[str, ...]] = {
   "VineDensity": (
     "check_estimators_dtypes",

--- a/tests/test_torch_vinedist.py
+++ b/tests/test_torch_vinedist.py
@@ -487,15 +487,13 @@ def test_holds_margins_with_atoms() -> None:
   u_np = u.detach().numpy()
 
   # Sklar's factorization, spelled out: the compiled vine supplies the copula
-  # term and the same torch margins supply theirs, so a wrong assembly -- a
-  # missing left limit, a mis-ordered column -- shows up as a wrong number.
-  # `structure=None`, as the torch fit used. Both selectors reuse the pairs they
-  # fitted while selecting, so a pair may arrive at its slot flipped -- and a
-  # flipped TLL fit is not the fit of the swapped arguments: the grid's margin
-  # renormalization runs a fixed three alternating sweeps, which does not commute
-  # with transposition (2.7e-4), and on a discrete edge the latent sample is
-  # drawn per column position on top of that (4.2e-3 on the density). Both are
-  # upstream's and reproduced exactly, so compare select to select.
+  # term and the same torch margins theirs, so a wrong assembly -- a missing
+  # left limit, a mis-ordered column -- is a wrong number. `structure=None`, as
+  # the torch fit used: both selectors reuse the pairs they fitted, so a pair
+  # can arrive at its slot flipped, and a flipped TLL fit is not the fit of the
+  # swapped arguments (2.7e-4 from the renormalization sweeps, 4.2e-3 more on a
+  # discrete edge). Both behaviors are upstream's, so compare select to
+  # select.
   cop = pv.Vinecop.from_data(
     u_np,
     var_types=["d", "c", "c"],


### PR DESCRIPTION
Rebased onto `main` now that #326 and #330 have landed; one commit, no
behavior change. It is a sweep over every comment block of five lines or more
in `src/` and `tests/`.

Most of them earn their length: a measured tolerance, an upstream source, the
reason a linter suppression is narrow. Those are untouched — deleting them
would remove reasons rather than verbosity. What is gone is the rest.

## Commented-out code

- `tests/conftest.py` carried an eleven-line `test_dump_folder` fixture,
  commented out, that nothing had ever used. The comment above
  `unique_json_path` — "If you prefer a unique file path directly:" — only
  made sense as a contrast with it.
- `tests/test_plots.py` carried a commented-out test asserting that
  `pairs_copula_data` refuses more than ten dimensions. It does not: I checked,
  and eleven columns are accepted. So the block was neither a test nor a plan
  for one, and restoring it would mean asserting a guard that has to be written
  first.

## Said twice

- `TorchVinecop.from_data` explained the thresholded-independence pair twice,
  fifteen lines apart — once above the assignment and again, at greater length,
  inside the list comprehension it annotates. The two agreed; one survives.
- The batched-cascade banner in `VinecopBase` enumerated the batched-vine
  surface (`bv.level(t)`, `gather_inputs`, `pdf_h1_h2`, the `needs_h*` masks)
  that the loops immediately below it read anyway.
- Three more stated their point and then restated it: the Sklar-factorization
  tolerance argument in `test_torch_vinedist.py`, the bounds comment in
  `sklearn/_base.py`, and two sklearn test comments wrapped twenty columns
  short of the line limit.

## History

`VinecopBase`'s `fit_edge` comment recorded a bug that dropping `x_e` once
caused — "Dropping it here is what let a non-simplified vine fit the simplified
model and evaluate the conditional one." What the code has to do stays; what it
used to do belongs to the commit that changed it, which is where `AGENTS.md`
puts it.

## Verification

Net 48 comment lines. `make check` clean after the rebase; the suites over
every file touched pass (325 tests, 2 skipped, 6 xfailed).
